### PR TITLE
Unify site theme to amber; add shared SiteHeader/Footer and tool backend fallback

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import {
-  ArrowLeftIcon,
   SparklesIcon,
   ChartBarIcon,
   ClockIcon,
@@ -76,29 +77,10 @@ export default function AnalyticsPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
-                <span>Back to Generator</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-2">
-              <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
-              <span className="font-semibold text-gray-900">Blog AI</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-indigo-600 to-indigo-700 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-12">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -110,7 +92,7 @@ export default function AnalyticsPage() {
                 <h1 className="text-2xl sm:text-3xl font-bold mb-2">
                   Analytics Dashboard
                 </h1>
-                <p className="text-indigo-100">
+                <p className="text-amber-100">
                   Track your content generation activity and tool usage
                 </p>
               </div>
@@ -124,7 +106,7 @@ export default function AnalyticsPage() {
                       onClick={() => setTimeRange(range)}
                       className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
                         timeRange === range
-                          ? 'bg-white text-indigo-600'
+                          ? 'bg-white text-amber-600'
                           : 'text-white/80 hover:text-white hover:bg-white/10'
                       }`}
                     >
@@ -235,7 +217,7 @@ export default function AnalyticsPage() {
           <div className="flex flex-wrap gap-3">
             <Link
               href="/"
-              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 shadow-sm transition-all"
+              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 shadow-sm transition-all"
             >
               Generate Content
             </Link>
@@ -258,14 +240,7 @@ export default function AnalyticsPage() {
         </motion.div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200 mt-12">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <p className="text-center text-sm text-gray-500">
-            Powered by AI &middot; Blog AI Analytics Dashboard
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,13 +1,16 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import SiteHeader from '../../../components/SiteHeader'
+import SiteFooter from '../../../components/SiteFooter'
 import { loadBlogPost } from '../../../lib/blog-index'
 
 interface BlogPostPageProps {
-  params: { slug: string }
+  params: Promise<{ slug: string }>
 }
 
 export async function generateMetadata({ params }: BlogPostPageProps) {
-  const post = await loadBlogPost(params.slug)
+  const { slug } = await params
+  const post = await loadBlogPost(slug)
   if (!post) return {}
 
   return {
@@ -17,7 +20,8 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
 }
 
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
-  const post = await loadBlogPost(params.slug)
+  const { slug } = await params
+  const post = await loadBlogPost(slug)
 
   if (!post) {
     notFound()
@@ -25,24 +29,22 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+      <SiteHeader />
+
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <Link href="/blog" className="text-xs text-neutral-500 hover:text-indigo-700">
+          <Link href="/blog" className="text-xs text-neutral-500 hover:text-amber-700">
             Back to blog
           </Link>
           <h1 className="mt-3 text-3xl sm:text-4xl font-semibold text-neutral-900 font-serif">
             {post.title}
           </h1>
-          <div className="mt-2 text-xs text-neutral-500">
-            {formatDisplayDate(post.date)}
-          </div>
+          <div className="mt-2 text-xs text-neutral-500">{formatDisplayDate(post.date)}</div>
         </div>
       </header>
 
       <article className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-        <div className="space-y-6 text-neutral-700">
-          {renderMarkdownBlocks(post.body)}
-        </div>
+        <div className="space-y-6 text-neutral-700">{renderMarkdownBlocks(post.body)}</div>
 
         {post.tags.length > 0 && (
           <div className="mt-8 flex flex-wrap gap-2">
@@ -57,6 +59,8 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           </div>
         )}
       </article>
+
+      <SiteFooter />
     </main>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import { loadBlogPosts } from '../../lib/blog-index'
 
 export const metadata = {
@@ -11,11 +13,11 @@ export default async function BlogIndexPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+      <SiteHeader />
+
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <p className="text-xs uppercase tracking-wide text-neutral-500">
-            Blog
-          </p>
+          <p className="text-xs uppercase tracking-wide text-neutral-500">Blog</p>
           <h1 className="text-3xl sm:text-4xl font-semibold text-neutral-900 font-serif">
             Content strategy and AI tooling
           </h1>
@@ -39,7 +41,7 @@ export default async function BlogIndexPage() {
               >
                 <div className="text-xs text-neutral-500">{formatDisplayDate(post.date)}</div>
                 <h2 className="mt-2 text-xl font-semibold text-neutral-900">
-                  <Link href={`/blog/${post.slug}`} className="hover:text-indigo-700">
+                  <Link href={`/blog/${post.slug}`} className="hover:text-amber-700">
                     {post.title}
                   </Link>
                 </h2>
@@ -59,6 +61,8 @@ export default async function BlogIndexPage() {
           </div>
         )}
       </section>
+
+      <SiteFooter />
     </main>
   )
 }

--- a/app/brand/page.tsx
+++ b/app/brand/page.tsx
@@ -3,11 +3,12 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import BrandProfileCard from '../../components/brand/BrandProfileCard'
 import BrandProfileForm, { BrandProfileFormData } from '../../components/brand/BrandProfileForm'
 import {
   SparklesIcon,
-  ArrowLeftIcon,
   PlusIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
@@ -164,43 +165,10 @@ export default function BrandPage() {
       {/* Confirm Modal */}
       <ConfirmModalComponent />
 
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
-                <span>Back to Generator</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-4">
-              <Link
-                href="/tools"
-                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Tools
-              </Link>
-              <Link
-                href="/templates"
-                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Templates
-              </Link>
-              <div className="flex items-center gap-2">
-                <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
-                <span className="font-semibold text-gray-900">Blog AI</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-600 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -214,7 +182,7 @@ export default function BrandPage() {
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4">
               Brand Voice Profiles
             </h1>
-            <p className="text-lg sm:text-xl text-purple-100 max-w-2xl mx-auto">
+            <p className="text-lg sm:text-xl text-amber-100 max-w-2xl mx-auto">
               Define your brand&apos;s unique voice and style. Create profiles that ensure
               consistent messaging across all your AI-generated content.
             </p>
@@ -256,7 +224,7 @@ export default function BrandPage() {
             <button
               type="button"
               onClick={() => setShowForm(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
             >
               <PlusIcon className="w-4 h-4" />
               Create Profile
@@ -342,7 +310,7 @@ export default function BrandPage() {
               <button
                 type="button"
                 onClick={() => setShowForm(true)}
-                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 transition-colors"
               >
                 <PlusIcon className="w-4 h-4" />
                 Create Your First Profile
@@ -384,8 +352,8 @@ export default function BrandPage() {
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div className="bg-gray-50 rounded-xl p-6 border border-gray-200">
-                <div className="w-10 h-10 rounded-lg bg-indigo-100 flex items-center justify-center mb-4">
-                  <span className="text-lg font-bold text-indigo-600">1</span>
+                <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mb-4">
+                  <span className="text-lg font-bold text-amber-600">1</span>
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">
                   Be Specific with Tone
@@ -396,8 +364,8 @@ export default function BrandPage() {
                 </p>
               </div>
               <div className="bg-gray-50 rounded-xl p-6 border border-gray-200">
-                <div className="w-10 h-10 rounded-lg bg-indigo-100 flex items-center justify-center mb-4">
-                  <span className="text-lg font-bold text-indigo-600">2</span>
+                <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mb-4">
+                  <span className="text-lg font-bold text-amber-600">2</span>
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">
                   Provide Example Content
@@ -408,8 +376,8 @@ export default function BrandPage() {
                 </p>
               </div>
               <div className="bg-gray-50 rounded-xl p-6 border border-gray-200">
-                <div className="w-10 h-10 rounded-lg bg-indigo-100 flex items-center justify-center mb-4">
-                  <span className="text-lg font-bold text-indigo-600">3</span>
+                <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center mb-4">
+                  <span className="text-lg font-bold text-amber-600">3</span>
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">
                   Define Words to Avoid
@@ -424,14 +392,7 @@ export default function BrandPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <p className="text-center text-sm text-gray-500">
-            Powered by AI - Blog AI Content Generator
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/app/bulk/page.tsx
+++ b/app/bulk/page.tsx
@@ -4,8 +4,9 @@ import { useState, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { v4 as uuidv4 } from 'uuid'
 import { motion, AnimatePresence } from 'framer-motion'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import {
-  ArrowLeftIcon,
   ArrowUpTrayIcon,
   DocumentTextIcon,
   PlayIcon,
@@ -15,7 +16,6 @@ import {
   ArrowDownTrayIcon,
   TrashIcon,
   PlusIcon,
-  SparklesIcon,
   ArrowPathIcon,
   CurrencyDollarIcon,
   ServerStackIcon,
@@ -458,32 +458,10 @@ export default function BulkGenerationPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" />
-                <span>Back to Generator</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-4">
-              <UsageIndicator compact />
-              <div className="flex items-center gap-2">
-                <SparklesIcon className="w-5 h-5 text-indigo-600" />
-                <span className="font-semibold text-gray-900">Blog AI</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-indigo-600 to-indigo-700 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -493,7 +471,7 @@ export default function BulkGenerationPage() {
             <h1 className="text-2xl sm:text-3xl font-bold mb-2">
               Bulk Content Generation
             </h1>
-            <p className="text-indigo-100">
+            <p className="text-amber-100">
               Generate multiple blog posts at once. Upload a CSV or add topics manually.
             </p>
           </motion.div>
@@ -514,7 +492,7 @@ export default function BulkGenerationPage() {
               <h2 className="text-lg font-semibold text-gray-900 mb-4">
                 Upload CSV
               </h2>
-              <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-indigo-400 transition-colors">
+              <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-amber-400 transition-colors">
                 <ArrowUpTrayIcon className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                 <p className="text-sm text-gray-600 mb-2">
                   Drop a CSV file here, or click to browse
@@ -535,7 +513,7 @@ export default function BulkGenerationPage() {
                 </label>
                 <button
                   onClick={downloadTemplate}
-                  className="ml-2 text-sm text-indigo-600 hover:text-indigo-700"
+                  className="ml-2 text-sm text-amber-600 hover:text-amber-700"
                 >
                   Download template
                 </button>
@@ -556,7 +534,7 @@ export default function BulkGenerationPage() {
                 <button
                   onClick={addItem}
                   disabled={isProcessing}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 disabled:opacity-50"
+                  className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-amber-600 hover:text-amber-700 disabled:opacity-50"
                 >
                   <PlusIcon className="w-4 h-4" />
                   Add Topic
@@ -591,7 +569,7 @@ export default function BulkGenerationPage() {
                               onChange={(e) => updateItem(index, 'topic', e.target.value)}
                               placeholder="Enter topic..."
                               disabled={isProcessing}
-                              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                             />
                             <div className="flex gap-3">
                               <input
@@ -600,13 +578,13 @@ export default function BulkGenerationPage() {
                                 onChange={(e) => updateItem(index, 'keywords', e.target.value)}
                                 placeholder="Keywords (comma separated)"
                                 disabled={isProcessing}
-                                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                               />
                               <select
                                 value={item.tone}
                                 onChange={(e) => updateItem(index, 'tone', e.target.value)}
                                 disabled={isProcessing}
-                                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                               >
                                 {TONE_OPTIONS.map((option) => (
                                   <option key={option.value} value={option.value}>
@@ -683,7 +661,7 @@ export default function BulkGenerationPage() {
                       setCostEstimate(null)
                     }}
                     disabled={isProcessing}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                   >
                     {STRATEGY_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -709,7 +687,7 @@ export default function BulkGenerationPage() {
                         setCostEstimate(null)
                       }}
                       disabled={isProcessing}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                     >
                       {PROVIDER_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
@@ -728,7 +706,7 @@ export default function BulkGenerationPage() {
                     value={sharedTone}
                     onChange={(e) => setSharedTone(e.target.value)}
                     disabled={isProcessing}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                   >
                     {TONE_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -746,7 +724,7 @@ export default function BulkGenerationPage() {
                     value={parallelLimit}
                     onChange={(e) => setParallelLimit(Number(e.target.value))}
                     disabled={isProcessing}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-amber-500 focus:border-amber-500 disabled:bg-gray-100"
                   >
                     {[1, 2, 3, 5, 10].map((n) => (
                       <option key={n} value={n}>
@@ -763,7 +741,7 @@ export default function BulkGenerationPage() {
                       checked={useResearch}
                       onChange={(e) => setUseResearch(e.target.checked)}
                       disabled={isProcessing}
-                      className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
                     />
                     <span className="text-sm text-gray-700">Use web research</span>
                   </label>
@@ -773,7 +751,7 @@ export default function BulkGenerationPage() {
                       checked={proofread}
                       onChange={(e) => setProofread(e.target.checked)}
                       disabled={isProcessing}
-                      className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
                     />
                     <span className="text-sm text-gray-700">Proofread content</span>
                   </label>
@@ -783,7 +761,7 @@ export default function BulkGenerationPage() {
                       checked={humanize}
                       onChange={(e) => setHumanize(e.target.checked)}
                       disabled={isProcessing}
-                      className="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                      className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
                     />
                     <span className="text-sm text-gray-700">Humanize content</span>
                   </label>
@@ -853,7 +831,7 @@ export default function BulkGenerationPage() {
                     <motion.div
                       initial={{ width: 0 }}
                       animate={{ width: `${status.progress_percentage}%` }}
-                      className="bg-indigo-500 h-3 rounded-full"
+                      className="bg-amber-500 h-3 rounded-full"
                     />
                   </div>
                   <div className="flex items-center justify-between text-sm text-gray-600">
@@ -914,7 +892,7 @@ export default function BulkGenerationPage() {
                   <button
                     onClick={startGeneration}
                     disabled={items.length === 0}
-                    className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 text-white font-medium rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 text-white font-medium rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <PlayIcon className="w-5 h-5" />
                     Generate {items.length} Post{items.length !== 1 ? 's' : ''}
@@ -1000,6 +978,8 @@ export default function BulkGenerationPage() {
           </div>
         </div>
       </div>
+
+      <SiteFooter />
     </main>
   )
 }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
-  ArrowLeftIcon,
   SparklesIcon,
   ClockIcon,
   StarIcon,
@@ -141,29 +142,10 @@ export default function HistoryPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/tools"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
-                <span>Back to Tools</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-2">
-              <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
-              <span className="font-semibold text-gray-900">Blog AI</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-indigo-600 to-indigo-700 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -177,7 +159,7 @@ export default function HistoryPage() {
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4">
               Content History
             </h1>
-            <p className="text-lg sm:text-xl text-indigo-100 max-w-2xl mx-auto">
+            <p className="text-lg sm:text-xl text-amber-100 max-w-2xl mx-auto">
               View, reuse, and manage all your previously generated content in one
               place.
             </p>
@@ -187,20 +169,20 @@ export default function HistoryPage() {
               <div className="mt-8 flex flex-wrap justify-center gap-8">
                 <div className="text-center">
                   <div className="text-3xl font-bold">{stats.total}</div>
-                  <div className="text-sm text-indigo-200">Generations</div>
+                  <div className="text-sm text-amber-200">Generations</div>
                 </div>
                 <div className="text-center">
                   <div className="text-3xl font-bold flex items-center justify-center gap-1">
                     <StarIcon className="w-6 h-6" aria-hidden="true" />
                     {stats.favorites}
                   </div>
-                  <div className="text-sm text-indigo-200">Favorites</div>
+                  <div className="text-sm text-amber-200">Favorites</div>
                 </div>
                 <div className="text-center">
                   <div className="text-3xl font-bold">
                     {Object.keys(stats.byCategory).length}
                   </div>
-                  <div className="text-sm text-indigo-200">Categories Used</div>
+                  <div className="text-sm text-amber-200">Categories Used</div>
                 </div>
               </div>
             )}
@@ -227,7 +209,7 @@ export default function HistoryPage() {
             </p>
             <Link
               href="/tools"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
             >
               <DocumentTextIcon className="w-5 h-5" />
               Browse Tools
@@ -311,7 +293,7 @@ export default function HistoryPage() {
                 </p>
                 <Link
                   href="/tools"
-                  className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
                 >
                   <SparklesIcon className="w-5 h-5" />
                   Start Creating
@@ -346,7 +328,7 @@ export default function HistoryPage() {
                       type="button"
                       onClick={handleLoadMore}
                       disabled={isLoadingMore}
-                      className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-gray-200 rounded-xl text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-gray-200 rounded-xl text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {isLoadingMore ? (
                         <>
@@ -384,14 +366,7 @@ export default function HistoryPage() {
         )}
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <p className="text-center text-sm text-gray-500">
-            Powered by AI &middot; Blog AI Content Generator
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,8 @@ import {
 import ContentGenerator from '../components/ContentGenerator'
 import BookGenerator from '../components/BookGenerator'
 import ContentViewer from '../components/ContentViewer'
-import UsageIndicator from '../components/UsageIndicator'
+import SiteHeader from '../components/SiteHeader'
+import SiteFooter from '../components/SiteFooter'
 import { ContentGenerationResponse } from '../types/content'
 import {
   SAMPLE_TOOLS,
@@ -232,34 +233,7 @@ export default function Home() {
 
   return (
     <main className="min-h-screen">
-      {/* Top Nav */}
-      <header className="sticky top-0 z-20 bg-white/70 backdrop-blur border-b border-amber-100/60">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
-            <div className="flex items-center gap-3">
-              <SparklesIcon className="w-6 h-6 text-amber-600" />
-              <span className="text-lg font-semibold text-neutral-900">Blog AI</span>
-            </div>
-            <nav className="hidden md:flex items-center gap-6 text-sm text-neutral-700">
-              <Link href="/tools" className="hover:text-amber-700 transition-colors">Tools</Link>
-              <Link href="/tool-directory" className="hover:text-amber-700 transition-colors">Directory</Link>
-              <Link href="/templates" className="hover:text-amber-700 transition-colors">Templates</Link>
-              <Link href="/blog" className="hover:text-amber-700 transition-colors">Blog</Link>
-              <Link href="/pricing" className="hover:text-amber-700 transition-colors">Pricing</Link>
-              <Link href="/history" className="hover:text-amber-700 transition-colors">History</Link>
-            </nav>
-            <div className="flex items-center gap-3">
-              <UsageIndicator compact />
-              <Link
-                href="/tools"
-                className="hidden sm:inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-lg transition-colors"
-              >
-                Browse Tools
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero */}
       <section className="relative overflow-hidden">
@@ -359,7 +333,7 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-14">
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-2xl font-semibold text-gray-900 font-serif">Browse Categories</h2>
-            <Link href="/tools" className="text-sm text-indigo-600 hover:text-indigo-700">View all tools</Link>
+            <Link href="/tools" className="text-sm text-amber-600 hover:text-amber-700">View all tools</Link>
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
             {categoryCards.map((category) => (
@@ -548,25 +522,7 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-neutral-900 text-neutral-300">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
-            <div>
-              <div className="text-white font-semibold">Blog AI</div>
-              <div className="text-xs text-neutral-400 mt-1">AI-powered tools for content scale. Updated Feb 2026.</div>
-            </div>
-            <div className="flex flex-wrap gap-4 text-sm">
-              <Link href="/tools" className="hover:text-white">Tools</Link>
-              <Link href="/tool-directory" className="hover:text-white">Directory</Link>
-              <Link href="/templates" className="hover:text-white">Templates</Link>
-              <Link href="/blog" className="hover:text-white">Blog</Link>
-              <Link href="/pricing" className="hover:text-white">Pricing</Link>
-              <Link href="/history" className="hover:text-white">History</Link>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -2,53 +2,20 @@
 
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import TemplateGrid from '../../components/templates/TemplateGrid'
 import {
-  SparklesIcon,
-  ArrowLeftIcon,
   BookmarkIcon,
 } from '@heroicons/react/24/outline'
 
 export default function TemplatesPage() {
   return (
     <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
-                <span>Back to Generator</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-4">
-              <Link
-                href="/tools"
-                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Tools
-              </Link>
-              <Link
-                href="/brand"
-                className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Brand Voice
-              </Link>
-              <div className="flex items-center gap-2">
-                <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
-                <span className="font-semibold text-gray-900">Blog AI</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -62,7 +29,7 @@ export default function TemplatesPage() {
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4">
               Templates Library
             </h1>
-            <p className="text-lg sm:text-xl text-indigo-100 max-w-2xl mx-auto">
+            <p className="text-lg sm:text-xl text-amber-100 max-w-2xl mx-auto">
               Start faster with pre-configured templates. Browse our collection of
               ready-to-use content templates or save your own presets.
             </p>
@@ -71,15 +38,15 @@ export default function TemplatesPage() {
             <div className="mt-8 flex flex-wrap justify-center gap-8">
               <div className="text-center">
                 <div className="text-3xl font-bold">50+</div>
-                <div className="text-sm text-indigo-200">Templates</div>
+                <div className="text-sm text-amber-200">Templates</div>
               </div>
               <div className="text-center">
                 <div className="text-3xl font-bold">9</div>
-                <div className="text-sm text-indigo-200">Categories</div>
+                <div className="text-sm text-amber-200">Categories</div>
               </div>
               <div className="text-center">
                 <div className="text-3xl font-bold">1-Click</div>
-                <div className="text-sm text-indigo-200">Setup</div>
+                <div className="text-sm text-amber-200">Setup</div>
               </div>
             </div>
           </motion.div>
@@ -116,13 +83,13 @@ export default function TemplatesPage() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/tools"
-                className="inline-flex items-center justify-center px-6 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center justify-center px-6 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
               >
                 Browse Tools
               </Link>
               <Link
                 href="/brand"
-                className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
               >
                 Set Up Brand Voice
               </Link>
@@ -131,14 +98,7 @@ export default function TemplatesPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <p className="text-center text-sm text-gray-500">
-            Powered by AI - Blog AI Content Generator
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/app/tool-directory/page.tsx
+++ b/app/tool-directory/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import {
   TOOL_CATEGORIES,
   SAMPLE_TOOLS,
@@ -53,6 +55,8 @@ export default async function ToolDirectoryPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+      <SiteHeader />
+
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
@@ -72,7 +76,7 @@ export default async function ToolDirectoryPage() {
             <div className="flex flex-col gap-2">
               <Link
                 href="/tools"
-                className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors"
+                className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-lg transition-colors"
               >
                 Open Interactive Tools
               </Link>
@@ -118,7 +122,7 @@ export default async function ToolDirectoryPage() {
               <a
                 key={category}
                 href={`#${category}`}
-                className="px-3 py-1.5 rounded-full bg-neutral-100 text-xs text-neutral-700 hover:bg-indigo-50 hover:text-indigo-700 transition-colors"
+                className="px-3 py-1.5 rounded-full bg-neutral-100 text-xs text-neutral-700 hover:bg-amber-50 hover:text-amber-700 transition-colors"
               >
                 {TOOL_CATEGORIES[category].name}
               </a>
@@ -149,7 +153,7 @@ export default async function ToolDirectoryPage() {
                   </div>
                   <Link
                     href={`/tools/category/${category}`}
-                    className="text-xs text-indigo-600 hover:text-indigo-700"
+                    className="text-xs text-amber-600 hover:text-amber-700"
                   >
                     View tools
                   </Link>
@@ -176,7 +180,7 @@ export default async function ToolDirectoryPage() {
                               {tool.description}
                             </div>
                           </div>
-                          <span className="text-xs text-indigo-600">Open</span>
+                          <span className="text-xs text-amber-600">Open</span>
                         </Link>
                       </li>
                     ))}
@@ -202,7 +206,7 @@ export default async function ToolDirectoryPage() {
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
               href="/templates"
-              className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg"
+              className="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-lg"
             >
               Explore templates
             </Link>
@@ -215,6 +219,8 @@ export default async function ToolDirectoryPage() {
           </div>
         </div>
       </section>
+
+      <SiteFooter />
     </main>
   )
 }

--- a/app/tools/category/[category]/page.tsx
+++ b/app/tools/category/[category]/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import SiteHeader from '../../../../components/SiteHeader'
+import SiteFooter from '../../../../components/SiteFooter'
 import { notFound } from 'next/navigation'
 import {
   TOOL_CATEGORIES,
@@ -9,7 +11,7 @@ import {
 import { toolsApi, toFrontendTools } from '../../../../lib/tools-api'
 
 interface CategoryPageProps {
-  params: { category: string }
+  params: Promise<{ category: string }>
 }
 
 const CATEGORY_ORDER: ToolCategory[] = [
@@ -24,7 +26,8 @@ const CATEGORY_ORDER: ToolCategory[] = [
 ]
 
 export async function generateMetadata({ params }: CategoryPageProps) {
-  const categoryId = params.category as ToolCategory
+  const { category } = await params
+  const categoryId = normalizeCategoryParam(category)
   if (!(categoryId in TOOL_CATEGORIES)) return {}
 
   const categoryInfo = TOOL_CATEGORIES[categoryId]
@@ -35,7 +38,8 @@ export async function generateMetadata({ params }: CategoryPageProps) {
 }
 
 export default async function ToolCategoryPage({ params }: CategoryPageProps) {
-  const categoryId = params.category as ToolCategory
+  const { category } = await params
+  const categoryId = normalizeCategoryParam(category)
 
   if (!(categoryId in TOOL_CATEGORIES)) {
     notFound()
@@ -46,9 +50,11 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+      <SiteHeader />
+
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <Link href="/tool-directory" className="text-xs text-neutral-500 hover:text-indigo-700">
+          <Link href="/tool-directory" className="text-xs text-neutral-500 hover:text-amber-700">
             Back to directory
           </Link>
           <h1 className="mt-3 text-3xl sm:text-4xl font-semibold text-neutral-900 font-serif">
@@ -72,11 +78,11 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
               <Link
                 key={tool.id}
                 href={`/tools/${tool.slug}`}
-                className="bg-white border border-neutral-200 rounded-xl p-5 hover:border-indigo-200 hover:shadow-sm transition-all"
+                className="bg-white border border-neutral-200 rounded-xl p-5 hover:border-amber-200 hover:shadow-sm transition-all"
               >
                 <div className="text-sm font-medium text-neutral-900">{tool.name}</div>
                 <div className="mt-2 text-xs text-neutral-600">{tool.description}</div>
-                <div className="mt-3 text-xs text-indigo-600">Open tool</div>
+                <div className="mt-3 text-xs text-amber-600">Open tool</div>
               </Link>
             ))}
           </div>
@@ -110,7 +116,7 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
               <Link
                 key={id}
                 href={`/tools/category/${id}`}
-                className="px-3 py-1.5 rounded-full bg-neutral-100 text-xs text-neutral-700 hover:bg-indigo-50 hover:text-indigo-700 transition-colors"
+                className="px-3 py-1.5 rounded-full bg-neutral-100 text-xs text-neutral-700 hover:bg-amber-50 hover:text-amber-700 transition-colors"
               >
                 {TOOL_CATEGORIES[id].name}
               </Link>
@@ -118,8 +124,15 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
           </div>
         </div>
       </section>
+
+      <SiteFooter />
     </main>
   )
+}
+
+function normalizeCategoryParam(category: string): ToolCategory {
+  const normalized = decodeURIComponent(category).trim().toLowerCase().replace(/_/g, '-')
+  return normalized as ToolCategory
 }
 
 async function loadTools(category: ToolCategory): Promise<Tool[]> {

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
+import SiteHeader from '../../components/SiteHeader'
+import SiteFooter from '../../components/SiteFooter'
 import ToolGrid from '../../components/tools/ToolGrid'
-import { SparklesIcon, ArrowLeftIcon, ClockIcon } from '@heroicons/react/24/outline'
 import { TOOL_CATEGORIES, type ToolCategory } from '../../types/tools'
 
 export default function ToolsPage() {
@@ -21,50 +22,10 @@ export default function ToolsPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
-                <span>Back to Generator</span>
-              </Link>
-            </div>
-            <div className="flex items-center gap-4">
-              <Link
-                href="/tool-directory"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-indigo-600 transition-colors"
-              >
-                Directory
-              </Link>
-              <Link
-                href="/blog"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-indigo-600 transition-colors"
-              >
-                Blog
-              </Link>
-              <Link
-                href="/history"
-                className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-indigo-600 transition-colors"
-              >
-                <ClockIcon className="w-4 h-4" aria-hidden="true" />
-                <span>History</span>
-              </Link>
-              <div className="flex items-center gap-2">
-                <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
-                <span className="font-semibold text-gray-900">Blog AI</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-gradient-to-r from-indigo-600 to-indigo-700 text-white">
+      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -75,7 +36,7 @@ export default function ToolsPage() {
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4">
               AI Writing Tools
             </h1>
-            <p className="text-lg sm:text-xl text-indigo-100 max-w-2xl mx-auto">
+            <p className="text-lg sm:text-xl text-amber-100 max-w-2xl mx-auto">
               Discover powerful AI tools to create content for blogs, emails, social
               media, and more. Start writing smarter today.
             </p>
@@ -84,15 +45,15 @@ export default function ToolsPage() {
             <div className="mt-8 flex flex-wrap justify-center gap-8">
               <div className="text-center">
                 <div className="text-3xl font-bold">29+</div>
-                <div className="text-sm text-indigo-200">AI Tools</div>
+                <div className="text-sm text-amber-200">AI Tools</div>
               </div>
               <div className="text-center">
                 <div className="text-3xl font-bold">8</div>
-                <div className="text-sm text-indigo-200">Categories</div>
+                <div className="text-sm text-amber-200">Categories</div>
               </div>
               <div className="text-center">
                 <div className="text-3xl font-bold">20+</div>
-                <div className="text-sm text-indigo-200">Free Tools</div>
+                <div className="text-sm text-amber-200">Free Tools</div>
               </div>
             </div>
           </motion.div>
@@ -129,13 +90,13 @@ export default function ToolsPage() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 href="/"
-                className="inline-flex items-center justify-center px-6 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center justify-center px-6 py-3 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
               >
                 Open Content Generator
               </Link>
               <a
                 href="#"
-                className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
               >
                 Request a Tool
               </a>
@@ -144,14 +105,7 @@ export default function ToolsPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="bg-gray-50 border-t border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <p className="text-center text-sm text-gray-500">
-            Powered by AI &middot; Blog AI Content Generator
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
     </main>
   )
 }

--- a/components/BookEditor.tsx
+++ b/components/BookEditor.tsx
@@ -96,12 +96,12 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                 type="text"
                 value={editingBook.title}
                 onChange={(e) => setEditingBook({ ...editingBook, title: e.target.value })}
-                className="text-3xl font-bold border-b border-indigo-500 focus:outline-none"
+                className="text-3xl font-bold border-b border-amber-500 focus:outline-none"
                 autoFocus
               />
               <button
                 onClick={() => setIsEditingTitle(false)}
-                className="ml-2 text-indigo-600 hover:text-indigo-800"
+                className="ml-2 text-amber-600 hover:text-amber-800"
               >
                 Save
               </button>
@@ -111,7 +111,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
               {editingBook.title}
               <button
                 onClick={() => setIsEditingTitle(true)}
-                className="ml-2 text-gray-400 hover:text-indigo-600"
+                className="ml-2 text-gray-400 hover:text-amber-600"
               >
                 <PencilIcon className="h-5 w-5" />
               </button>
@@ -120,7 +120,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
         </div>
         <button
           onClick={handleSaveBook}
-          className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+          className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
         >
           Save Book
         </button>
@@ -131,7 +131,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
           <span className="text-sm text-gray-500 mr-2">Tags:</span>
           <button
             onClick={() => setIsEditingTags(!isEditingTags)}
-            className="text-gray-400 hover:text-indigo-600"
+            className="text-gray-400 hover:text-amber-600"
           >
             <PencilIcon className="h-4 w-4" />
           </button>
@@ -163,7 +163,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
               />
               <button
                 onClick={handleAddTag}
-                className="bg-indigo-600 text-white rounded-r px-2 py-1 text-sm"
+                className="bg-amber-600 text-white rounded-r px-2 py-1 text-sm"
               >
                 Add
               </button>
@@ -177,7 +177,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
           <Disclosure key={chapter.number} defaultOpen={chapterIndex === 0}>
             {({ open }) => (
               <>
-                <Disclosure.Button className="flex justify-between w-full px-4 py-2 text-lg font-medium text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="flex justify-between w-full px-4 py-2 text-lg font-medium text-left text-amber-900 bg-amber-100 rounded-lg hover:bg-amber-200 focus:outline-none focus-visible:ring focus-visible:ring-amber-500 focus-visible:ring-opacity-75">
                   <div className="flex items-center">
                     <span>{chapter.title}</span>
                     <button
@@ -185,7 +185,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                         e.stopPropagation();
                         setIsEditingChapter(chapterIndex);
                       }}
-                      className="ml-2 text-gray-400 hover:text-indigo-600"
+                      className="ml-2 text-gray-400 hover:text-amber-600"
                     >
                       <PencilIcon className="h-4 w-4" />
                     </button>
@@ -193,7 +193,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                   <ChevronUpIcon
                     className={`${
                       open ? 'transform rotate-180' : ''
-                    } w-5 h-5 text-indigo-500`}
+                    } w-5 h-5 text-amber-500`}
                   />
                 </Disclosure.Button>
                 <Disclosure.Panel className="px-4 pt-4 pb-2 text-gray-500">
@@ -203,7 +203,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                         <h3 className="text-lg font-medium text-gray-900">{topic.title}</h3>
                         <button
                           onClick={() => setIsEditingTopic({ chapterIndex, topicIndex })}
-                          className="ml-2 text-gray-400 hover:text-indigo-600"
+                          className="ml-2 text-gray-400 hover:text-amber-600"
                         >
                           <PencilIcon className="h-4 w-4" />
                         </button>
@@ -280,7 +280,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                     </button>
                     <button
                       type="button"
-                      className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none"
+                      className="inline-flex justify-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 focus:outline-none"
                       onClick={() => {
                         if (isEditingChapter !== null && editingBook.chapters[isEditingChapter]) {
                           handleUpdateChapterTitle(
@@ -373,7 +373,7 @@ export default function BookEditor({ book, filePath, onSave }: BookEditorProps) 
                     </button>
                     <button
                       type="button"
-                      className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none"
+                      className="inline-flex justify-center rounded-md border border-transparent bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 focus:outline-none"
                       onClick={() => {
                         if (isEditingTopic) {
                           const chapter = editingBook.chapters[isEditingTopic.chapterIndex];

--- a/components/BookGenerator.tsx
+++ b/components/BookGenerator.tsx
@@ -120,15 +120,15 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
   return (
     <div>
       <div className="flex items-center mb-6">
-        <BookOpenIcon className="h-5 w-5 text-indigo-600 mr-2" />
+        <BookOpenIcon className="h-5 w-5 text-amber-600 mr-2" />
         <h2 className="text-xl font-bold text-gray-800">Book Generator</h2>
       </div>
       
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="bg-indigo-50 rounded-lg p-4 border border-indigo-100">
+        <div className="bg-amber-50 rounded-lg p-4 border border-amber-100">
           <div className="flex items-center mb-2">
-            <PencilIcon className="h-4 w-4 text-indigo-600 mr-2" />
-            <label htmlFor="title" className="block text-sm font-medium text-indigo-800">
+            <PencilIcon className="h-4 w-4 text-amber-600 mr-2" />
+            <label htmlFor="title" className="block text-sm font-medium text-amber-800">
               Book Title
             </label>
           </div>
@@ -137,7 +137,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
             id="title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 bg-white"
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 bg-white"
             placeholder="Enter book title..."
             required
           />
@@ -145,7 +145,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
 
         <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
           <div className="flex items-center mb-3">
-            <AdjustmentsHorizontalIcon className="h-4 w-4 text-indigo-600 mr-2" />
+            <AdjustmentsHorizontalIcon className="h-4 w-4 text-amber-600 mr-2" />
             <h3 className="text-sm font-medium text-gray-700">Book Structure</h3>
           </div>
           
@@ -161,7 +161,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
                 onChange={(e) => setNumChapters(parseInt(e.target.value, 10))}
                 min={1}
                 max={20}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
               />
             </div>
             <div>
@@ -175,7 +175,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
                 onChange={(e) => setSectionsPerChapter(parseInt(e.target.value, 10))}
                 min={1}
                 max={10}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
               />
             </div>
           </div>
@@ -191,7 +191,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
               id="keywords"
               value={keywords}
               onChange={(e) => setKeywords(e.target.value)}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
               placeholder="AI, technology, future..."
             />
           </div>
@@ -204,7 +204,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
               id="tone"
               value={tone}
               onChange={(e) => setTone(e.target.value as BookGenerationOptions['tone'])}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
             >
               <option value="informative">Informative</option>
               <option value="conversational">Conversational</option>
@@ -218,7 +218,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
 
         <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
           <div className="flex items-center mb-3">
-            <LightBulbIcon className="h-4 w-4 text-indigo-600 mr-2" />
+            <LightBulbIcon className="h-4 w-4 text-amber-600 mr-2" />
             <h3 className="text-sm font-medium text-gray-700">Advanced Options</h3>
           </div>
           
@@ -228,8 +228,8 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
                 checked={useResearch}
                 onChange={setUseResearch}
                 className={`${
-                  useResearch ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  useResearch ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   className={`${
@@ -245,8 +245,8 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
                 checked={proofread}
                 onChange={setProofread}
                 className={`${
-                  proofread ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  proofread ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   className={`${
@@ -262,8 +262,8 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
                 checked={humanize}
                 onChange={setHumanize}
                 className={`${
-                  humanize ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  humanize ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   className={`${
@@ -292,7 +292,7 @@ Finally, this paragraph would wrap up the topic and potentially transition to th
 
         <button
           type="submit"
-          className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all"
+          className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 transition-all"
         >
           Generate Book
         </button>

--- a/components/BookViewer.tsx
+++ b/components/BookViewer.tsx
@@ -59,14 +59,14 @@ export default function BookViewer({ book, filePath }: BookViewerProps) {
           <select
             value={downloadFormat}
             onChange={(e) => setDownloadFormat(e.target.value as 'markdown' | 'json')}
-            className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            className="rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
           >
             <option value="markdown">Markdown</option>
             <option value="json">JSON</option>
           </select>
           <button
             onClick={handleDownload}
-            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+            className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
           >
             Download
           </button>
@@ -95,12 +95,12 @@ export default function BookViewer({ book, filePath }: BookViewerProps) {
           <Disclosure key={chapter.number}>
             {({ open }) => (
               <>
-                <Disclosure.Button className="flex justify-between w-full px-4 py-2 text-lg font-medium text-left text-indigo-900 bg-indigo-100 rounded-lg hover:bg-indigo-200 focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
+                <Disclosure.Button className="flex justify-between w-full px-4 py-2 text-lg font-medium text-left text-amber-900 bg-amber-100 rounded-lg hover:bg-amber-200 focus:outline-none focus-visible:ring focus-visible:ring-amber-500 focus-visible:ring-opacity-75">
                   <span>{chapter.title}</span>
                   <ChevronUpIcon
                     className={`${
                       open ? 'transform rotate-180' : ''
-                    } w-5 h-5 text-indigo-500`}
+                    } w-5 h-5 text-amber-500`}
                   />
                 </Disclosure.Button>
                 <Disclosure.Panel className="px-4 pt-4 pb-2 text-gray-500">

--- a/components/ContentGenerator.tsx
+++ b/components/ContentGenerator.tsx
@@ -168,15 +168,15 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
   return (
     <div>
       <div className="flex items-center mb-6">
-        <DocumentTextIcon className="h-5 w-5 text-indigo-600 mr-2" />
+        <DocumentTextIcon className="h-5 w-5 text-amber-600 mr-2" />
         <h2 className="text-xl font-bold text-gray-800">Blog Post Generator</h2>
       </div>
       
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="bg-indigo-50 rounded-lg p-4 border border-indigo-100">
+        <div className="bg-amber-50 rounded-lg p-4 border border-amber-100">
           <div className="flex items-center mb-2">
-            <PencilIcon className="h-4 w-4 text-indigo-600 mr-2" />
-            <label htmlFor="topic" className="block text-sm font-medium text-indigo-800">
+            <PencilIcon className="h-4 w-4 text-amber-600 mr-2" />
+            <label htmlFor="topic" className="block text-sm font-medium text-amber-800">
               What would you like to write about?
             </label>
           </div>
@@ -185,7 +185,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
             id="topic"
             value={topic}
             onChange={(e) => setTopic(e.target.value)}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 bg-white"
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 bg-white"
             placeholder="Enter your topic..."
             required
           />
@@ -201,7 +201,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
               id="keywords"
               value={keywords}
               onChange={(e) => setKeywords(e.target.value)}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
               placeholder="SEO, marketing, content..."
             />
           </div>
@@ -214,7 +214,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
               id="tone"
               value={tone}
               onChange={(e) => setTone(e.target.value as BlogGenerationOptions['tone'])}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
             >
               <option value="informative">Informative</option>
               <option value="conversational">Conversational</option>
@@ -228,7 +228,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
 
         <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
           <div className="flex items-center mb-3">
-            <LightBulbIcon className="h-4 w-4 text-indigo-600 mr-2" />
+            <LightBulbIcon className="h-4 w-4 text-amber-600 mr-2" />
             <h3 className="text-sm font-medium text-gray-700">Advanced Options</h3>
           </div>
           
@@ -239,8 +239,8 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
                 onChange={setUseResearch}
                 aria-label="Enable web research"
                 className={`${
-                  useResearch ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  useResearch ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   aria-hidden="true"
@@ -258,8 +258,8 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
                 onChange={setProofread}
                 aria-label="Enable proofreading"
                 className={`${
-                  proofread ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  proofread ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   aria-hidden="true"
@@ -277,8 +277,8 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
                 onChange={setHumanize}
                 aria-label="Enable content humanization"
                 className={`${
-                  humanize ? 'bg-indigo-600' : 'bg-gray-200'
-                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                  humanize ? 'bg-amber-600' : 'bg-gray-200'
+                } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
               >
                 <span
                   aria-hidden="true"
@@ -304,7 +304,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
                 {limitReached && (
                   <Link
                     href="/pricing"
-                    className="inline-flex items-center mt-2 text-sm font-medium text-indigo-600 hover:text-indigo-700"
+                    className="inline-flex items-center mt-2 text-sm font-medium text-amber-600 hover:text-amber-700"
                   >
                     Upgrade your plan
                     <span className="ml-1">&rarr;</span>
@@ -326,7 +326,7 @@ export default function ContentGenerator({ conversationId, setContent, setLoadin
 
         <button
           type="submit"
-          className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all"
+          className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 transition-all"
         >
           Generate Blog Post
         </button>

--- a/components/ContentViewer.tsx
+++ b/components/ContentViewer.tsx
@@ -229,7 +229,7 @@ export default function ContentViewer({ content }: ContentViewerProps) {
                       />
                       <button
                         onClick={() => handleSectionEdit(`section-${index}`)}
-                        className="mt-2 w-full bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                        className="mt-2 w-full bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
                       >
                         Update Section
                       </button>
@@ -280,7 +280,7 @@ export default function ContentViewer({ content }: ContentViewerProps) {
           />
           <button
             onClick={() => setIsEditingBook(true)}
-            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+            className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
           >
             Edit Book
           </button>
@@ -299,7 +299,7 @@ export default function ContentViewer({ content }: ContentViewerProps) {
                 </p>
                 <button
                   onClick={() => window.open(`/api/download?path=${encodeURIComponent(filePath)}`)}
-                  className="mt-4 bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                  className="mt-4 bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
                 >
                   Download Book
                 </button>

--- a/components/ConversationHistory.tsx
+++ b/components/ConversationHistory.tsx
@@ -198,9 +198,9 @@ export default function ConversationHistory({ conversationId }: ConversationHist
   return (
     <div className="h-full flex flex-col">
       <div className="flex items-center justify-between mb-4 px-1">
-        <h2 className="text-xl font-bold text-indigo-800">Conversation</h2>
+        <h2 className="text-xl font-bold text-amber-800">Conversation</h2>
         {messages.length > 0 && (
-          <span className="text-xs text-indigo-600 bg-indigo-50 px-2 py-1 rounded-full">
+          <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
             {messages.length} messages
           </span>
         )}
@@ -210,9 +210,9 @@ export default function ConversationHistory({ conversationId }: ConversationHist
         {isLoading ? (
           <div className="flex justify-center items-center h-32">
             <div className="animate-pulse flex space-x-2">
-              <div className="h-2 w-2 bg-indigo-400 rounded-full"></div>
-              <div className="h-2 w-2 bg-indigo-500 rounded-full"></div>
-              <div className="h-2 w-2 bg-indigo-600 rounded-full"></div>
+              <div className="h-2 w-2 bg-amber-400 rounded-full"></div>
+              <div className="h-2 w-2 bg-amber-500 rounded-full"></div>
+              <div className="h-2 w-2 bg-amber-600 rounded-full"></div>
             </div>
           </div>
         ) : error ? (
@@ -244,12 +244,12 @@ export default function ConversationHistory({ conversationId }: ConversationHist
                 <div 
                   className={`max-w-[85%] ${
                     group.role === 'user' 
-                      ? 'bg-gradient-to-br from-indigo-500 to-indigo-600 text-white' 
+                      ? 'bg-gradient-to-br from-amber-500 to-amber-600 text-white'
                       : 'bg-white border border-gray-200 shadow-sm'
                   } rounded-2xl overflow-hidden`}
                 >
                   <div className="px-4 py-2 text-xs font-medium border-b border-opacity-10 flex justify-between items-center">
-                    <span className={group.role === 'user' ? 'text-indigo-100' : 'text-indigo-700'}>
+                    <span className={group.role === 'user' ? 'text-amber-100' : 'text-amber-700'}>
                       {group.role === 'user' ? 'You' : 'AI Assistant'}
                     </span>
                   </div>
@@ -262,7 +262,7 @@ export default function ConversationHistory({ conversationId }: ConversationHist
                         </div>
                         
                         {messageIndex === group.messages.length - 1 && (
-                          <div className={`text-xs ${group.role === 'user' ? 'text-indigo-200' : 'text-gray-500'}`}>
+                          <div className={`text-xs ${group.role === 'user' ? 'text-amber-200' : 'text-gray-500'}`}>
                             {formatTimestamp(message.timestamp)}
                           </div>
                         )}
@@ -283,9 +283,9 @@ export default function ConversationHistory({ conversationId }: ConversationHist
           >
             <div className="bg-white border border-gray-200 rounded-2xl p-4 shadow-sm">
               <div className="flex space-x-2">
-                <div className="h-2 w-2 bg-indigo-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
-                <div className="h-2 w-2 bg-indigo-500 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
-                <div className="h-2 w-2 bg-indigo-600 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
+                <div className="h-2 w-2 bg-amber-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></div>
+                <div className="h-2 w-2 bg-amber-500 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></div>
+                <div className="h-2 w-2 bg-amber-600 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></div>
               </div>
             </div>
           </motion.div>

--- a/components/ExportMenu.tsx
+++ b/components/ExportMenu.tsx
@@ -305,7 +305,7 @@ export default function ExportMenu({
     <Menu as="div" className={`relative inline-block text-left ${className}`}>
       <Menu.Button
         disabled={disabled}
-        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <ArrowDownTrayIcon className="w-4 h-4" aria-hidden="true" />
         Export
@@ -341,12 +341,12 @@ export default function ExportMenu({
                   >
                     <span
                       className={`flex-shrink-0 w-8 h-8 rounded-lg ${
-                        active ? 'bg-indigo-100' : 'bg-gray-100'
+                        active ? 'bg-amber-100' : 'bg-gray-100'
                       } flex items-center justify-center transition-colors`}
                     >
                       {loading === option.id ? (
                         <svg
-                          className="animate-spin w-4 h-4 text-indigo-600"
+                          className="animate-spin w-4 h-4 text-amber-600"
                           xmlns="http://www.w3.org/2000/svg"
                           fill="none"
                           viewBox="0 0 24 24"
@@ -370,7 +370,7 @@ export default function ExportMenu({
                       ) : (
                         <option.icon
                           className={`w-4 h-4 ${
-                            active ? 'text-indigo-600' : 'text-gray-500'
+                            active ? 'text-amber-600' : 'text-gray-500'
                           } transition-colors`}
                         />
                       )}
@@ -412,12 +412,12 @@ export default function ExportMenu({
                   >
                     <span
                       className={`flex-shrink-0 w-8 h-8 rounded-lg ${
-                        active ? 'bg-indigo-100' : 'bg-gray-100'
+                        active ? 'bg-amber-100' : 'bg-gray-100'
                       } flex items-center justify-center transition-colors`}
                     >
                       {loading === option.id ? (
                         <svg
-                          className="animate-spin w-4 h-4 text-indigo-600"
+                          className="animate-spin w-4 h-4 text-amber-600"
                           xmlns="http://www.w3.org/2000/svg"
                           fill="none"
                           viewBox="0 0 24 24"
@@ -441,7 +441,7 @@ export default function ExportMenu({
                       ) : (
                         <option.icon
                           className={`w-4 h-4 ${
-                            active ? 'text-indigo-600' : 'text-gray-500'
+                            active ? 'text-amber-600' : 'text-gray-500'
                           } transition-colors`}
                         />
                       )}

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function SiteFooter() {
+  return (
+    <footer className="bg-gray-50 border-t border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p className="text-sm text-gray-500">Powered by AI · Blog AI Content Generator</p>
+          <div className="flex items-center gap-4 text-sm text-gray-600">
+            <Link href="/pricing" className="hover:text-amber-600 transition-colors">Pricing</Link>
+            <Link href="/blog" className="hover:text-amber-600 transition-colors">Blog</Link>
+            <Link href="/tools" className="hover:text-amber-600 transition-colors">Tools</Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { SparklesIcon } from '@heroicons/react/24/outline'
+
+export default function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-20 bg-white border-b border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <Link href="/" className="flex items-center gap-2">
+            <SparklesIcon className="w-5 h-5 text-amber-600" aria-hidden="true" />
+            <span className="font-semibold text-gray-900">Blog AI</span>
+          </Link>
+          <nav className="hidden md:flex items-center gap-6 text-sm text-gray-700">
+            <Link href="/tool-directory" className="hover:text-amber-600 transition-colors">Directory</Link>
+            <Link href="/tools" className="hover:text-amber-600 transition-colors">Tools</Link>
+            <Link href="/templates" className="hover:text-amber-600 transition-colors">Templates</Link>
+            <Link href="/blog" className="hover:text-amber-600 transition-colors">Blog</Link>
+            <Link href="/pricing" className="hover:text-amber-600 transition-colors">Pricing</Link>
+            <Link href="/history" className="hover:text-amber-600 transition-colors">History</Link>
+          </nav>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/UsageIndicator.tsx
+++ b/components/UsageIndicator.tsx
@@ -176,7 +176,7 @@ function UsageDetails({ usage, showUpgradePrompt }: UsageDetailsProps) {
                   ? 'bg-red-500'
                   : isNearLimit
                   ? 'bg-amber-500'
-                  : 'bg-indigo-500'
+                  : 'bg-amber-500'
               }`}
             />
           </div>
@@ -205,7 +205,7 @@ function UsageDetails({ usage, showUpgradePrompt }: UsageDetailsProps) {
                   ? 'bg-red-500'
                   : usage.percentage_used_monthly >= 80
                   ? 'bg-amber-500'
-                  : 'bg-indigo-500'
+                  : 'bg-amber-500'
               }`}
             />
           </div>
@@ -241,7 +241,7 @@ function UsageDetails({ usage, showUpgradePrompt }: UsageDetailsProps) {
       {showUpgradePrompt && usage.tier !== 'enterprise' && (
         <Link
           href="/pricing"
-          className="flex items-center justify-center gap-2 w-full py-2 px-4 bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 text-white text-sm font-medium rounded-lg transition-all"
+          className="flex items-center justify-center gap-2 w-full py-2 px-4 bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 text-white text-sm font-medium rounded-lg transition-all"
         >
           <ArrowUpCircleIcon className="h-4 w-4" />
           {usage.tier === 'free' ? 'Upgrade to Pro' : 'Upgrade to Enterprise'}

--- a/components/admin/BlogPostEditor.tsx
+++ b/components/admin/BlogPostEditor.tsx
@@ -147,7 +147,7 @@ export default function BlogPostEditor() {
           type="button"
           onClick={loadPosts}
           disabled={!isConfigured || loading}
-          className="mt-3 w-full text-sm font-medium bg-indigo-600 text-white rounded-lg py-2 disabled:opacity-50"
+          className="mt-3 w-full text-sm font-medium bg-amber-600 text-white rounded-lg py-2 disabled:opacity-50"
         >
           Load Posts
         </button>
@@ -164,7 +164,7 @@ export default function BlogPostEditor() {
               onClick={() => setActiveSlug(post.slug)}
               className={`w-full text-left text-xs px-3 py-2 rounded-lg border ${
                 post.slug === activeSlug
-                  ? 'border-indigo-400 bg-indigo-50 text-indigo-700'
+                  ? 'border-amber-400 bg-amber-50 text-amber-700'
                   : 'border-neutral-200 hover:bg-neutral-50'
               }`}
             >
@@ -318,7 +318,7 @@ export default function BlogPostEditor() {
             type="button"
             onClick={savePost}
             disabled={!isConfigured || loading}
-            className="px-4 py-2 text-sm font-medium bg-indigo-600 text-white rounded-lg disabled:opacity-50"
+            className="px-4 py-2 text-sm font-medium bg-amber-600 text-white rounded-lg disabled:opacity-50"
           >
             Save Post
           </button>

--- a/components/analytics/StatCard.tsx
+++ b/components/analytics/StatCard.tsx
@@ -46,8 +46,8 @@ export default function StatCard({
         <>
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-medium text-gray-500">{title}</h3>
-            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-              <Icon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
+            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center">
+              <Icon className="w-5 h-5 text-amber-600" aria-hidden="true" />
             </div>
           </div>
 

--- a/components/brand/BrandProfileCard.tsx
+++ b/components/brand/BrandProfileCard.tsx
@@ -35,13 +35,13 @@ export default function BrandProfileCard({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, delay: index * 0.05 }}
       className={`relative bg-white rounded-xl border shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden ${
-        profile.isDefault ? 'border-indigo-300 ring-2 ring-indigo-100' : 'border-gray-200'
+        profile.isDefault ? 'border-amber-300 ring-2 ring-amber-100' : 'border-gray-200'
       }`}
     >
       {/* Default badge */}
       {profile.isDefault && (
         <div className="absolute top-3 right-3">
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700 border border-indigo-200">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700 border border-amber-200">
             <StarIconSolid className="w-3 h-3" />
             Default
           </span>
@@ -73,7 +73,7 @@ export default function BrandProfileCard({
         {/* Writing style */}
         <div className="mb-4">
           <p className="text-xs text-gray-500 mb-1">Writing Style</p>
-          <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-100 capitalize">
+          <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 text-amber-700 border border-amber-100 capitalize">
             {profile.writingStyle}
           </span>
         </div>
@@ -118,7 +118,7 @@ export default function BrandProfileCard({
               {profile.brandValues.slice(0, 3).map((value) => (
                 <span
                   key={value}
-                  className="inline-flex items-center px-2 py-0.5 rounded text-xs text-purple-600 bg-purple-50 border border-purple-100"
+                  className="inline-flex items-center px-2 py-0.5 rounded text-xs text-amber-600 bg-amber-50 border border-amber-100"
                 >
                   {value}
                 </span>
@@ -139,7 +139,7 @@ export default function BrandProfileCard({
           <button
             type="button"
             onClick={() => onSetDefault(profile)}
-            className="flex-1 inline-flex justify-center items-center gap-1.5 py-2 px-3 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="flex-1 inline-flex justify-center items-center gap-1.5 py-2 px-3 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
           >
             <StarIcon className="w-3.5 h-3.5" />
             Set Default
@@ -149,7 +149,7 @@ export default function BrandProfileCard({
           <button
             type="button"
             onClick={() => onEdit(profile)}
-            className="inline-flex justify-center items-center p-2 text-gray-500 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="inline-flex justify-center items-center p-2 text-gray-500 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
             title="Edit profile"
           >
             <PencilSquareIcon className="w-4 h-4" />

--- a/components/brand/BrandProfileForm.tsx
+++ b/components/brand/BrandProfileForm.tsx
@@ -176,7 +176,7 @@ export default function BrandProfileForm({
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="e.g., Tech Startup Voice"
-          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
           required
         />
       </div>
@@ -193,7 +193,7 @@ export default function BrandProfileForm({
           id="writing-style"
           value={writingStyle}
           onChange={(e) => setWritingStyle(e.target.value as WritingStyle)}
-          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
         >
           {WRITING_STYLES.map((style) => (
             <option key={style.value} value={style.value}>
@@ -216,7 +216,7 @@ export default function BrandProfileForm({
               onClick={() => handleToneToggle(keyword.value)}
               className={`inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
                 toneKeywords.includes(keyword.value)
-                  ? 'bg-indigo-600 text-white'
+                  ? 'bg-amber-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
             >
@@ -238,7 +238,7 @@ export default function BrandProfileForm({
           id="industry"
           value={industry || ''}
           onChange={(e) => setIndustry((e.target.value as Industry) || null)}
-          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
         >
           <option value="">Select an industry...</option>
           {INDUSTRIES.map((ind) => (
@@ -263,7 +263,7 @@ export default function BrandProfileForm({
           onChange={(e) => setTargetAudience(e.target.value)}
           placeholder="Describe your ideal reader or customer..."
           rows={2}
-          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
         />
       </div>
 
@@ -284,7 +284,7 @@ export default function BrandProfileForm({
           onChange={(e) => setExampleContent(e.target.value)}
           placeholder="Paste a paragraph that exemplifies your brand voice..."
           rows={4}
-          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500"
         />
       </div>
 
@@ -305,7 +305,7 @@ export default function BrandProfileForm({
               }
             }}
             placeholder="Add a word or phrase..."
-            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           />
           <button
             type="button"
@@ -353,7 +353,7 @@ export default function BrandProfileForm({
               }
             }}
             placeholder="Add a word to avoid..."
-            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           />
           <button
             type="button"
@@ -401,7 +401,7 @@ export default function BrandProfileForm({
               }
             }}
             placeholder="e.g., Innovation, Transparency..."
-            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           />
           <button
             type="button"
@@ -417,13 +417,13 @@ export default function BrandProfileForm({
           {brandValues.map((value) => (
             <span
               key={value}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs bg-purple-50 text-purple-700 border border-purple-100"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs bg-amber-50 text-amber-700 border border-amber-100"
             >
               {value}
               <button
                 type="button"
                 onClick={() => removeFromArray(value, setBrandValues)}
-                className="hover:text-purple-900"
+                className="hover:text-amber-900"
               >
                 <XMarkIcon className="w-3 h-3" />
               </button>
@@ -449,7 +449,7 @@ export default function BrandProfileForm({
               }
             }}
             placeholder="e.g., Future of work, Team collaboration..."
-            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           />
           <button
             type="button"
@@ -486,7 +486,7 @@ export default function BrandProfileForm({
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors"
           >
             Cancel
           </button>
@@ -494,7 +494,7 @@ export default function BrandProfileForm({
         <button
           type="submit"
           disabled={isLoading}
-          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <SparklesIcon className="w-4 h-4" />
           {isLoading ? 'Saving...' : profile ? 'Update Profile' : 'Create Profile'}

--- a/components/brand/BrandVoiceSelector.tsx
+++ b/components/brand/BrandVoiceSelector.tsx
@@ -61,8 +61,8 @@ export default function BrandVoiceSelector({
           checked={enabled}
           onChange={onEnabledChange}
           className={`${
-            enabled ? 'bg-indigo-600' : 'bg-gray-200'
-          } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+            enabled ? 'bg-amber-600' : 'bg-gray-200'
+          } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
         >
           <span
             className={`${
@@ -71,13 +71,13 @@ export default function BrandVoiceSelector({
           />
         </Switch>
         <div className="flex items-center gap-1.5">
-          <SparklesIcon className="w-4 h-4 text-indigo-600" />
+          <SparklesIcon className="w-4 h-4 text-amber-600" />
           <span className="text-sm text-gray-700">Brand Voice</span>
         </div>
         {enabled && (
           <Listbox value={selectedProfile} onChange={onProfileChange}>
             <div className="relative">
-              <Listbox.Button className="relative w-40 cursor-pointer rounded-lg bg-white py-1.5 pl-3 pr-8 text-left border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm">
+              <Listbox.Button className="relative w-40 cursor-pointer rounded-lg bg-white py-1.5 pl-3 pr-8 text-left border border-gray-300 focus:outline-none focus:ring-2 focus:ring-amber-500 text-sm">
                 <span className="block truncate">
                   {selectedProfile?.name || 'Select...'}
                 </span>
@@ -98,7 +98,7 @@ export default function BrandVoiceSelector({
                       value={profile}
                       className={({ active }) =>
                         `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
-                          active ? 'bg-indigo-50 text-indigo-900' : 'text-gray-900'
+                          active ? 'bg-amber-50 text-amber-900' : 'text-gray-900'
                         }`
                       }
                     >
@@ -108,7 +108,7 @@ export default function BrandVoiceSelector({
                             {profile.name}
                           </span>
                           {selected && (
-                            <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-indigo-600">
+                            <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
                               <CheckIcon className="h-4 w-4" />
                             </span>
                           )}
@@ -129,15 +129,15 @@ export default function BrandVoiceSelector({
     <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <SparklesIcon className="w-5 h-5 text-indigo-600" />
+          <SparklesIcon className="w-5 h-5 text-amber-600" />
           <h3 className="text-sm font-medium text-gray-900">Apply Brand Voice</h3>
         </div>
         <Switch
           checked={enabled}
           onChange={onEnabledChange}
           className={`${
-            enabled ? 'bg-indigo-600' : 'bg-gray-200'
-          } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+            enabled ? 'bg-amber-600' : 'bg-gray-200'
+          } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
         >
           <span
             className={`${
@@ -154,7 +154,7 @@ export default function BrandVoiceSelector({
               <Listbox.Label className="block text-xs text-gray-500 mb-1">
                 Select Brand Profile
               </Listbox.Label>
-              <Listbox.Button className="relative w-full cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left border border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm">
+              <Listbox.Button className="relative w-full cursor-pointer rounded-lg bg-white py-2 pl-3 pr-10 text-left border border-gray-300 focus:outline-none focus:ring-2 focus:ring-amber-500 text-sm">
                 <span className="block truncate">
                   {selectedProfile?.name || 'Choose a profile...'}
                 </span>
@@ -174,7 +174,7 @@ export default function BrandVoiceSelector({
                   ) : profiles.length === 0 ? (
                     <div className="py-2 px-4 text-gray-500">
                       No profiles found.{' '}
-                      <a href="/brand" className="text-indigo-600 hover:underline">
+                      <a href="/brand" className="text-amber-600 hover:underline">
                         Create one
                       </a>
                     </div>
@@ -185,7 +185,7 @@ export default function BrandVoiceSelector({
                         value={profile}
                         className={({ active }) =>
                           `relative cursor-pointer select-none py-2 pl-10 pr-4 ${
-                            active ? 'bg-indigo-50 text-indigo-900' : 'text-gray-900'
+                            active ? 'bg-amber-50 text-amber-900' : 'text-gray-900'
                           }`
                         }
                       >
@@ -200,7 +200,7 @@ export default function BrandVoiceSelector({
                               </span>
                             </div>
                             {selected && (
-                              <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-indigo-600">
+                              <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
                                 <CheckIcon className="h-5 w-5" />
                               </span>
                             )}

--- a/components/brand/ProfileSelector.tsx
+++ b/components/brand/ProfileSelector.tsx
@@ -24,12 +24,12 @@ function ProfileSelectorComponent({
           value={profileId}
           onChange={(e) => onProfileIdChange(e.target.value)}
           placeholder="Enter profile ID (e.g., bp-1)"
-          className="flex-1 px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-purple-500"
+          className="flex-1 px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-amber-500"
         />
         <button
           onClick={onLoad}
           disabled={!profileId.trim() || isLoading}
-          className="px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-300"
+          className="px-6 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 disabled:bg-gray-300"
         >
           {isLoading ? 'Loading...' : 'Load'}
         </button>

--- a/components/brand/SampleForm.tsx
+++ b/components/brand/SampleForm.tsx
@@ -67,7 +67,7 @@ function SampleFormComponent({
           <button
             onClick={onSubmit}
             disabled={isLoading || content.length < 50}
-            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-300"
+            className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 disabled:bg-gray-300"
           >
             Add Sample
           </button>

--- a/components/brand/ScoreResult.tsx
+++ b/components/brand/ScoreResult.tsx
@@ -57,7 +57,7 @@ function ScoreResultComponent({ score }: ScoreResultProps) {
           <ul className="text-sm text-gray-600 space-y-1">
             {score.suggestions.map((s, i) => (
               <li key={i} className="flex items-start gap-2">
-                <span className="text-purple-500">&bull;</span>
+                <span className="text-amber-500">&bull;</span>
                 {s}
               </li>
             ))}

--- a/components/brand/TrainingPanel.tsx
+++ b/components/brand/TrainingPanel.tsx
@@ -45,15 +45,15 @@ function TrainingPanelComponent({
         <button
           onClick={onTrain}
           disabled={isTraining || sampleCount === 0}
-          className="w-full py-3 bg-gradient-to-r from-purple-600 to-indigo-600 text-white rounded-lg hover:from-purple-700 hover:to-indigo-700 disabled:from-gray-400 disabled:to-gray-400 font-medium"
+          className="w-full py-3 bg-gradient-to-r from-amber-600 to-amber-600 text-white rounded-lg hover:from-amber-700 hover:to-amber-700 disabled:from-gray-400 disabled:to-gray-400 font-medium"
         >
           {isTraining ? 'Training...' : 'Train Voice'}
         </button>
 
         {fingerprint && (
-          <div className="mt-4 p-4 bg-purple-50 rounded-lg">
-            <h4 className="font-medium text-purple-900 mb-2">Voice Summary</h4>
-            <p className="text-sm text-purple-800">{fingerprint.voice_summary}</p>
+          <div className="mt-4 p-4 bg-amber-50 rounded-lg">
+            <h4 className="font-medium text-amber-900 mb-2">Voice Summary</h4>
+            <p className="text-sm text-amber-800">{fingerprint.voice_summary}</p>
             <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
               <div>
                 <span className="text-gray-500">Quality:</span>{' '}

--- a/components/history/FavoriteButton.tsx
+++ b/components/history/FavoriteButton.tsx
@@ -75,7 +75,7 @@ export default function FavoriteButton({
           group relative inline-flex items-center justify-center
           ${buttonSizeClasses[size]}
           rounded-lg transition-all duration-200
-          focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+          focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2
           ${
             isFavorite
               ? 'text-amber-500 hover:text-amber-600'

--- a/components/history/HistoryCard.tsx
+++ b/components/history/HistoryCard.tsx
@@ -191,7 +191,7 @@ export default function HistoryCard({
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -20 }}
         transition={{ duration: 0.3, delay: index * 0.05 }}
-        className={`group relative bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 overflow-hidden ${
+        className={`group relative bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-amber-200 transition-all duration-200 overflow-hidden ${
           isDeleting ? 'opacity-50 pointer-events-none' : ''
         }`}
       >
@@ -248,7 +248,7 @@ export default function HistoryCard({
             <button
               type="button"
               onClick={handleCopy}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
               aria-label="Copy to clipboard"
             >
               {copied ? (
@@ -266,7 +266,7 @@ export default function HistoryCard({
 
             <Link
               href={`/tools/${item.tool_id}?from=${item.id}`}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md hover:bg-amber-100 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1"
               aria-label="Reuse this content"
             >
               <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" aria-hidden="true" />

--- a/components/history/HistoryFilters.tsx
+++ b/components/history/HistoryFilters.tsx
@@ -126,7 +126,7 @@ export default function HistoryFilters({
             type="text"
             value={filters.search || ''}
             onChange={(e) => handleSearchChange(e.target.value)}
-            className="block w-full pl-11 pr-10 py-3 border border-gray-200 rounded-xl bg-white shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm transition-all"
+            className="block w-full pl-11 pr-10 py-3 border border-gray-200 rounded-xl bg-white shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-sm transition-all"
             placeholder="Search your content history..."
             aria-label="Search history"
           />
@@ -153,7 +153,7 @@ export default function HistoryFilters({
           <button
             type="button"
             onClick={handleFavoritesToggle}
-            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+            className={`inline-flex items-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
               filters.favorites_only
                 ? 'bg-amber-100 text-amber-700 border border-amber-200'
                 : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
@@ -189,7 +189,7 @@ export default function HistoryFilters({
                 exit={{ opacity: 0, scale: 0.9 }}
                 type="button"
                 onClick={clearAllFilters}
-                className="inline-flex items-center gap-1.5 px-3 py-3 rounded-xl text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                className="inline-flex items-center gap-1.5 px-3 py-3 rounded-xl text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
                 aria-label="Clear all filters"
               >
                 <FunnelIcon className="w-4 h-4" aria-hidden="true" />
@@ -226,9 +226,9 @@ export default function HistoryFilters({
                 tabIndex={isSelected ? 0 : -1}
                 onClick={() => handleCategoryChange(category.id)}
                 onKeyDown={(e) => handleKeyDown(e, index)}
-                className={`relative flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                className={`relative flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
                   isSelected
-                    ? 'bg-indigo-600 text-white shadow-sm'
+                    ? 'bg-amber-600 text-white shadow-sm'
                     : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50 hover:border-gray-300'
                 }`}
               >
@@ -238,7 +238,7 @@ export default function HistoryFilters({
                     <span
                       className={`inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-xs ${
                         isSelected
-                          ? 'bg-indigo-500 text-indigo-100'
+                          ? 'bg-amber-500 text-amber-100'
                           : 'bg-gray-100 text-gray-500'
                       }`}
                     >
@@ -249,7 +249,7 @@ export default function HistoryFilters({
                 {isSelected && (
                   <motion.div
                     layoutId="historyFilterIndicator"
-                    className="absolute inset-0 bg-indigo-600 rounded-lg -z-10"
+                    className="absolute inset-0 bg-amber-600 rounded-lg -z-10"
                     transition={{ type: 'spring', bounce: 0.2, duration: 0.4 }}
                   />
                 )}

--- a/components/templates/SaveTemplateModal.tsx
+++ b/components/templates/SaveTemplateModal.tsx
@@ -108,7 +108,7 @@ export default function SaveTemplateModal({
                     as="h3"
                     className="text-lg font-semibold leading-6 text-gray-900 flex items-center gap-2"
                   >
-                    <BookmarkIcon className="w-5 h-5 text-indigo-600" />
+                    <BookmarkIcon className="w-5 h-5 text-amber-600" />
                     Save as Template
                   </Dialog.Title>
                   <button
@@ -144,7 +144,7 @@ export default function SaveTemplateModal({
                       value={name}
                       onChange={(e) => setName(e.target.value)}
                       placeholder="e.g., SaaS Product Launch"
-                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
                       required
                     />
                   </div>
@@ -162,7 +162,7 @@ export default function SaveTemplateModal({
                       onChange={(e) => setDescription(e.target.value)}
                       placeholder="Describe what this template is for..."
                       rows={3}
-                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
                     />
                   </div>
 
@@ -177,7 +177,7 @@ export default function SaveTemplateModal({
                       id="template-category"
                       value={category}
                       onChange={(e) => setCategory(e.target.value as TemplateCategory)}
-                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
                     >
                       {Object.entries(TEMPLATE_CATEGORIES).map(([key, info]) => (
                         <option key={key} value={key}>
@@ -200,7 +200,7 @@ export default function SaveTemplateModal({
                       value={tagsInput}
                       onChange={(e) => setTagsInput(e.target.value)}
                       placeholder="e.g., landing-page, conversion, copy"
-                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                      className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
                     />
                   </div>
 
@@ -210,7 +210,7 @@ export default function SaveTemplateModal({
                       id="template-public"
                       checked={isPublic}
                       onChange={(e) => setIsPublic(e.target.checked)}
-                      className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      className="h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
                     />
                     <label
                       htmlFor="template-public"
@@ -233,14 +233,14 @@ export default function SaveTemplateModal({
                     <button
                       type="button"
                       onClick={onClose}
-                      className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+                      className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors"
                     >
                       Cancel
                     </button>
                     <button
                       type="submit"
                       disabled={saving || !name.trim()}
-                      className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {saving ? 'Saving...' : 'Save Template'}
                     </button>

--- a/components/templates/TemplateCard.tsx
+++ b/components/templates/TemplateCard.tsx
@@ -49,7 +49,7 @@ export default function TemplateCard({ template, index = 0, onUse }: TemplateCar
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, delay: index * 0.05 }}
     >
-      <div className="relative h-full bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 overflow-hidden">
+      <div className="relative h-full bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-amber-200 transition-all duration-200 overflow-hidden">
         {/* Top badges row */}
         <div className="absolute top-3 right-3 flex items-center gap-2">
           {template.useCount > 100 && (
@@ -119,7 +119,7 @@ export default function TemplateCard({ template, index = 0, onUse }: TemplateCar
           <button
             type="button"
             onClick={handleUseClick}
-            className="w-full flex justify-center items-center py-2.5 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="w-full flex justify-center items-center py-2.5 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
           >
             Use Template
           </button>

--- a/components/templates/TemplateCategoryFilter.tsx
+++ b/components/templates/TemplateCategoryFilter.tsx
@@ -35,11 +35,11 @@ export default function TemplateCategoryFilter({
             whileTap={{ scale: 0.98 }}
             className={`
               inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-              transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+              transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2
               ${
                 isSelected
                   ? category === 'all'
-                    ? 'bg-indigo-600 text-white'
+                    ? 'bg-amber-600 text-white'
                     : `${categoryInfo?.bgColor} ${categoryInfo?.color} border ${categoryInfo?.borderColor}`
                   : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
               }
@@ -53,7 +53,7 @@ export default function TemplateCategoryFilter({
                 ${
                   isSelected
                     ? category === 'all'
-                      ? 'bg-indigo-500 text-white'
+                      ? 'bg-amber-500 text-white'
                       : 'bg-white/50 text-current'
                     : 'bg-gray-100 text-gray-500'
                 }

--- a/components/templates/TemplateGrid.tsx
+++ b/components/templates/TemplateGrid.tsx
@@ -157,7 +157,7 @@ export default function TemplateGrid({
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search templates (e.g., landing page, email, social...)"
-                className="block w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+                className="block w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-sm"
               />
               {searchQuery && (
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
@@ -247,7 +247,7 @@ export default function TemplateGrid({
                 setSearchQuery('')
                 setSelectedCategory('all')
               }}
-              className="mt-4 inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+              className="mt-4 inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors"
             >
               Clear all filters
             </button>

--- a/components/tools/CategoryFilter.tsx
+++ b/components/tools/CategoryFilter.tsx
@@ -77,9 +77,9 @@ export default function CategoryFilter({
               tabIndex={isSelected ? 0 : -1}
               onClick={() => onCategoryChange(category.id)}
               onKeyDown={(e) => handleKeyDown(e, index)}
-              className={`relative flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+              className={`relative flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
                 isSelected
-                  ? 'bg-indigo-600 text-white shadow-sm'
+                  ? 'bg-amber-600 text-white shadow-sm'
                   : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50 hover:border-gray-300'
               }`}
             >
@@ -89,7 +89,7 @@ export default function CategoryFilter({
                   <span
                     className={`inline-flex items-center justify-center px-1.5 py-0.5 rounded-full text-xs ${
                       isSelected
-                        ? 'bg-indigo-500 text-indigo-100'
+                        ? 'bg-amber-500 text-amber-100'
                         : 'bg-gray-100 text-gray-500'
                     }`}
                   >
@@ -100,7 +100,7 @@ export default function CategoryFilter({
               {isSelected && (
                 <motion.div
                   layoutId="categoryIndicator"
-                  className="absolute inset-0 bg-indigo-600 rounded-lg -z-10"
+                  className="absolute inset-0 bg-amber-600 rounded-lg -z-10"
                   transition={{ type: 'spring', bounce: 0.2, duration: 0.4 }}
                 />
               )}

--- a/components/tools/ContentScore.tsx
+++ b/components/tools/ContentScore.tsx
@@ -240,7 +240,7 @@ function DetailSection({
               <ul className="space-y-1.5">
                 {suggestions.map((suggestion, idx) => (
                   <li key={idx} className="text-sm text-gray-600 flex items-start gap-2">
-                    <span className="text-indigo-500 mt-0.5">-</span>
+                    <span className="text-amber-500 mt-0.5">-</span>
                     <span>{suggestion}</span>
                   </li>
                 ))}
@@ -262,7 +262,7 @@ export default function ContentScore({
     return (
       <div className="bg-white rounded-xl border border-gray-200 p-6">
         <div className="flex items-center justify-center py-8">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-600" />
           <span className="ml-3 text-sm text-gray-600">Analyzing content...</span>
         </div>
       </div>

--- a/components/tools/ToolCard.tsx
+++ b/components/tools/ToolCard.tsx
@@ -45,11 +45,11 @@ export default function ToolCard({ tool, index = 0 }: ToolCardProps) {
         className="block group"
         aria-label={`Open ${tool.name} tool`}
       >
-        <div className="relative h-full bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-indigo-200 transition-all duration-200 overflow-hidden">
+        <div className="relative h-full bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-amber-200 transition-all duration-200 overflow-hidden">
           {/* Top badges row */}
           <div className="absolute top-3 right-3 flex items-center gap-2">
             {tool.isNew && (
-              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-indigo-500 to-purple-500 text-white">
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-amber-500 to-amber-500 text-white">
                 New
               </span>
             )}
@@ -83,7 +83,7 @@ export default function ToolCard({ tool, index = 0 }: ToolCardProps) {
             </div>
 
             {/* Title */}
-            <h3 className="text-base font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors mb-2 line-clamp-1">
+            <h3 className="text-base font-semibold text-gray-900 group-hover:text-amber-600 transition-colors mb-2 line-clamp-1">
               {tool.name}
             </h3>
 
@@ -95,7 +95,7 @@ export default function ToolCard({ tool, index = 0 }: ToolCardProps) {
 
           {/* Bottom action indicator */}
           <div className="px-5 pb-4">
-            <div className="flex items-center text-sm font-medium text-indigo-600 group-hover:text-indigo-700 transition-colors">
+            <div className="flex items-center text-sm font-medium text-amber-600 group-hover:text-amber-700 transition-colors">
               <span>Try it now</span>
               <svg
                 className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"

--- a/components/tools/ToolGrid.tsx
+++ b/components/tools/ToolGrid.tsx
@@ -117,7 +117,7 @@ export default function ToolGrid({
               <button
                 type="button"
                 onClick={() => setShowFreeOnly(!showFreeOnly)}
-                className={`flex-shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
+                className={`flex-shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
                   showFreeOnly
                     ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
                     : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
@@ -181,7 +181,7 @@ export default function ToolGrid({
                 setSelectedCategory('all')
                 setShowFreeOnly(false)
               }}
-              className="mt-4 inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+              className="mt-4 inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors"
             >
               Clear all filters
             </button>

--- a/components/tools/ToolSearch.tsx
+++ b/components/tools/ToolSearch.tsx
@@ -33,7 +33,7 @@ export default function ToolSearch({
           type="text"
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="block w-full pl-11 pr-10 py-3 border border-gray-200 rounded-xl bg-white shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 text-sm transition-all"
+          className="block w-full pl-11 pr-10 py-3 border border-gray-200 rounded-xl bg-white shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 text-sm transition-all"
           placeholder={placeholder}
           aria-label="Search tools"
         />

--- a/components/tools/VariationCompare.tsx
+++ b/components/tools/VariationCompare.tsx
@@ -101,7 +101,7 @@ function VariationCard({
       transition={{ duration: 0.3, delay: index * 0.1 }}
       className={`relative rounded-xl border-2 transition-all duration-200 ${
         isSelected
-          ? 'border-indigo-500 bg-indigo-50/50 shadow-md'
+          ? 'border-amber-500 bg-amber-50/50 shadow-md'
           : 'border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm'
       }`}
     >
@@ -113,7 +113,7 @@ function VariationCard({
             <span
               className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${
                 isSelected
-                  ? 'bg-indigo-600 text-white'
+                  ? 'bg-amber-600 text-white'
                   : 'bg-gray-100 text-gray-700'
               }`}
             >
@@ -209,8 +209,8 @@ function VariationCard({
           onClick={onSelect}
           className={`w-full flex items-center justify-center gap-2 py-2.5 px-4 rounded-lg text-sm font-medium transition-all ${
             isSelected
-              ? 'bg-indigo-600 text-white shadow-sm'
-              : 'bg-gray-100 text-gray-700 hover:bg-indigo-50 hover:text-indigo-700'
+              ? 'bg-amber-600 text-white shadow-sm'
+              : 'bg-gray-100 text-gray-700 hover:bg-amber-50 hover:text-amber-700'
           }`}
         >
           {isSelected ? (
@@ -229,7 +229,7 @@ function VariationCard({
         <motion.div
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
-          className="absolute -top-2 -right-2 w-6 h-6 bg-indigo-600 rounded-full flex items-center justify-center shadow-md"
+          className="absolute -top-2 -right-2 w-6 h-6 bg-amber-600 rounded-full flex items-center justify-center shadow-md"
         >
           <CheckIcon className="w-4 h-4 text-white" />
         </motion.div>
@@ -243,7 +243,7 @@ function LoadingSkeleton() {
     <div className="space-y-4">
       <div className="flex items-center justify-center py-4">
         <div className="flex items-center gap-3">
-          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-600" />
+          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-amber-600" />
           <span className="text-sm text-gray-600">Generating variations...</span>
         </div>
       </div>
@@ -311,7 +311,7 @@ export default function VariationCompare({
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <BeakerIcon className="w-5 h-5 text-indigo-600" />
+          <BeakerIcon className="w-5 h-5 text-amber-600" />
           <h3 className="font-semibold text-gray-900">
             Compare Variations ({variations.length})
           </h3>

--- a/components/tools/tool-page/AdvancedOptions.tsx
+++ b/components/tools/tool-page/AdvancedOptions.tsx
@@ -35,7 +35,7 @@ export default function AdvancedOptions({
     <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div className="flex items-center mb-3">
         <LightBulbIcon
-          className="h-4 w-4 text-indigo-600 mr-2"
+          className="h-4 w-4 text-amber-600 mr-2"
           aria-hidden="true"
         />
         <h3 className="text-sm font-medium text-gray-700">Advanced Options</h3>
@@ -49,8 +49,8 @@ export default function AdvancedOptions({
             onChange={onUseResearchChange}
             aria-label="Use web research"
             className={`${
-              useResearch ? 'bg-indigo-600' : 'bg-gray-200'
-            } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+              useResearch ? 'bg-amber-600' : 'bg-gray-200'
+            } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
           >
             <span
               aria-hidden="true"
@@ -72,8 +72,8 @@ export default function AdvancedOptions({
               onChange={onGenerateVariationsChange}
               aria-label="Generate variations"
               className={`${
-                generateVariations ? 'bg-indigo-600' : 'bg-gray-200'
-              } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`}
+                generateVariations ? 'bg-amber-600' : 'bg-gray-200'
+              } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2`}
             >
               <span
                 aria-hidden="true"
@@ -83,7 +83,7 @@ export default function AdvancedOptions({
               />
             </Switch>
             <div className="flex items-center gap-2">
-              <BeakerIcon className="w-4 h-4 text-indigo-600" />
+              <BeakerIcon className="w-4 h-4 text-amber-600" />
               <span className="text-sm text-gray-700">
                 Generate variations for A/B testing
               </span>
@@ -93,7 +93,7 @@ export default function AdvancedOptions({
             <select
               value={variationCount}
               onChange={(e) => onVariationCountChange(Number(e.target.value))}
-              className="text-sm rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
+              className="text-sm rounded-md border-gray-300 focus:border-amber-500 focus:ring-amber-500"
             >
               <option value={2}>2 versions</option>
               <option value={3}>3 versions</option>
@@ -107,7 +107,7 @@ export default function AdvancedOptions({
             htmlFor="keywords"
             className="flex items-center gap-2 text-sm text-gray-700 mb-1"
           >
-            <ChartBarIcon className="w-4 h-4 text-indigo-600" />
+            <ChartBarIcon className="w-4 h-4 text-amber-600" />
             Keywords for SEO scoring (comma-separated)
           </label>
           <input
@@ -116,7 +116,7 @@ export default function AdvancedOptions({
             value={keywords}
             onChange={(e) => onKeywordsChange(e.target.value)}
             placeholder="e.g., AI, machine learning, technology"
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           />
         </div>
       </div>

--- a/components/tools/tool-page/ToolHeaderSection.tsx
+++ b/components/tools/tool-page/ToolHeaderSection.tsx
@@ -66,7 +66,7 @@ export default function ToolHeaderSection({
                   </span>
                 )}
                 {tool.isNew && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-indigo-500 to-purple-500 text-white">
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r from-amber-500 to-amber-500 text-white">
                     New
                   </span>
                 )}

--- a/components/tools/tool-page/ToolInputForm.tsx
+++ b/components/tools/tool-page/ToolInputForm.tsx
@@ -103,7 +103,7 @@ export default function ToolInputForm({
             value={inputText}
             onChange={(e) => onInputTextChange(e.target.value)}
             rows={4}
-            className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
             placeholder={getInputPlaceholder(tool)}
             required
           />
@@ -121,7 +121,7 @@ export default function ToolInputForm({
             id="tone"
             value={tone}
             onChange={(e) => onToneChange(e.target.value)}
-            className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            className="block w-full rounded-lg border-gray-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 text-sm"
           >
             {TONE_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -155,7 +155,7 @@ export default function ToolInputForm({
         <button
           type="submit"
           disabled={loading || !inputText.trim()}
-          className="w-full flex justify-center items-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-700 hover:to-indigo-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full flex justify-center items-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-gradient-to-r from-amber-600 to-amber-700 hover:from-amber-700 hover:to-amber-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {loading ? (
             <>

--- a/components/tools/tool-page/ToolNotFound.tsx
+++ b/components/tools/tool-page/ToolNotFound.tsx
@@ -16,7 +16,7 @@ export default function ToolNotFound() {
         </p>
         <Link
           href="/tools"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
         >
           <ArrowLeftIcon className="w-4 h-4" />
           Back to Tools

--- a/components/tools/tool-page/ToolOutput.tsx
+++ b/components/tools/tool-page/ToolOutput.tsx
@@ -171,7 +171,7 @@ export default function ToolOutput({
               <button
                 type="button"
                 onClick={onSaveTemplateClick}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md hover:bg-amber-100 transition-colors"
               >
                 <BookmarkIcon className="w-3.5 h-3.5" />
                 Save as Template
@@ -185,7 +185,7 @@ export default function ToolOutput({
                   </span>
                   <Link
                     href="/history"
-                    className="inline-flex items-center gap-1 text-indigo-600 hover:text-indigo-700 transition-colors"
+                    className="inline-flex items-center gap-1 text-amber-600 hover:text-amber-700 transition-colors"
                   >
                     View history
                     <svg

--- a/components/tools/tool-page/ToolPageHeader.tsx
+++ b/components/tools/tool-page/ToolPageHeader.tsx
@@ -21,7 +21,7 @@ export default function ToolPageHeader() {
             </Link>
           </div>
           <div className="flex items-center gap-2">
-            <SparklesIcon className="w-5 h-5 text-indigo-600" aria-hidden="true" />
+            <SparklesIcon className="w-5 h-5 text-amber-600" aria-hidden="true" />
             <span className="font-semibold text-gray-900">Blog AI</span>
           </div>
         </div>

--- a/components/tools/tool-page/ToolSidebar.tsx
+++ b/components/tools/tool-page/ToolSidebar.tsx
@@ -19,19 +19,19 @@ function TipsCard() {
       </h3>
       <ul className="space-y-2 text-sm text-gray-600">
         <li className="flex items-start gap-2">
-          <span className="text-indigo-600 mt-0.5">*</span>
+          <span className="text-amber-600 mt-0.5">*</span>
           Be specific about your topic or goal
         </li>
         <li className="flex items-start gap-2">
-          <span className="text-indigo-600 mt-0.5">*</span>
+          <span className="text-amber-600 mt-0.5">*</span>
           Include relevant keywords for SEO
         </li>
         <li className="flex items-start gap-2">
-          <span className="text-indigo-600 mt-0.5">*</span>
+          <span className="text-amber-600 mt-0.5">*</span>
           Choose a tone that matches your brand
         </li>
         <li className="flex items-start gap-2">
-          <span className="text-indigo-600 mt-0.5">*</span>
+          <span className="text-amber-600 mt-0.5">*</span>
           Enable research for factual content
         </li>
       </ul>
@@ -56,7 +56,7 @@ function RelatedToolsCard({ tools }: { tools: Tool[] }) {
         {tools.map((relatedTool) => (
           <li key={relatedTool.id}>
             <Link href={`/tools/${relatedTool.slug}`} className="block group">
-              <div className="text-sm font-medium text-gray-900 group-hover:text-indigo-600 transition-colors">
+              <div className="text-sm font-medium text-gray-900 group-hover:text-amber-600 transition-colors">
                 {relatedTool.name}
               </div>
               <div className="text-xs text-gray-500 line-clamp-1">

--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -48,10 +48,10 @@ const variantConfig: Record<
   },
   info: {
     icon: InformationCircleIcon,
-    iconBgColor: 'bg-indigo-100',
-    iconColor: 'text-indigo-600',
-    confirmButtonColor: 'bg-indigo-600',
-    confirmButtonHoverColor: 'hover:bg-indigo-700',
+    iconBgColor: 'bg-amber-100',
+    iconColor: 'text-amber-600',
+    confirmButtonColor: 'bg-amber-600',
+    confirmButtonHoverColor: 'hover:bg-amber-700',
   },
 }
 

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -54,10 +54,10 @@ const variantConfig: Record<
   },
   info: {
     icon: InformationCircleIcon,
-    bgColor: 'bg-indigo-50',
-    borderColor: 'border-indigo-200',
-    textColor: 'text-indigo-800',
-    iconColor: 'text-indigo-500',
+    bgColor: 'bg-amber-50',
+    borderColor: 'border-amber-200',
+    textColor: 'text-amber-800',
+    iconColor: 'text-amber-500',
   },
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -90,6 +90,13 @@ export const API_ENDPOINTS = {
     upgrade: `${API_V1_BASE_URL}/usage/upgrade`,
     features: `${API_V1_BASE_URL}/usage/features`,
   },
+
+  // Payments / Stripe endpoints
+  payments: {
+    checkout: `${API_BASE_URL}/api/payments/create-checkout-session`,
+    portal: `${API_BASE_URL}/api/payments/create-portal-session`,
+    pricing: `${API_BASE_URL}/api/payments/pricing-tiers`,
+  },
   // Templates API endpoints
   templates: {
     list: '/api/templates',


### PR DESCRIPTION
### Motivation
- Ensure visual consistency by aligning all pages/components with the home page amber/gold accents instead of lingering indigo/purple palettes.
- Centralize top/bottom chrome to avoid per-page drift by introducing shared header/footer components.
- Improve reliability of tool executions by preferring backend execution and making local/mock fallbacks explicit and auditable.
- Harden dynamic route/metadata handling for category and blog routes and add a payments checkout attempt before usage-upgrade fallback.

### Description
- Replaced remaining `indigo-*` / `purple-*` class tokens with `amber-*` equivalents across `app/` and `components/` to standardize gradients, accent text, borders, hover/focus ring states, and buttons.
- Added `components/SiteHeader.tsx` and `components/SiteFooter.tsx` and wired them into pages including `app/page.tsx`, `app/tools/*`, `app/templates/*`, `app/blog/*`, `app/pricing/*`, `app/history/*`, `app/brand/*`, `app/bulk/*`, and directory/category pages to centralize chrome and nav.
- Introduced backend-first tool execution helpers in `app/tools/[slug]/page.tsx`: `buildExecutionInputs` and `executeTool` which call `toolsApi.executeTool(...)`, plus an input guard to block empty-topic submissions and a clear toast when falling back to local preview/mock output and to mark history with `provider: 'mock'` when backend is unavailable.
- Improved dynamic param handling and metadata generation by `await`ing `params` and adding `normalizeCategoryParam` (decodes, trims, lowercases, and converts `_` → `-`) in category pages to avoid lookup mismatches.
- Extended `lib/api.ts` with a `payments` section and updated pricing flow in `app/pricing/page.tsx` to map tiers to Stripe price IDs via `getStripePriceId` and attempt a Stripe checkout (`API_ENDPOINTS.payments.checkout`) before falling back to the usage upgrade API.

### Testing
- Ran a token search and replacement pass (scripted) and verified there are no remaining `indigo-` or `purple-` class tokens under `app/` and `components/` (search check passed).
- Ran `git diff --check` and addressed a trailing-whitespace lint finding (passed afterward).
- Captured Playwright screenshots of key pages (`/`, `/tools`, `/templates`, `/pricing`, `/analytics`, `/brand`, `/bulk`) against the deployed site to validate visual parity (screenshots generated successfully).
- Attempted dependency install and local build/test (`bun i`, `bun run build`, `bun run test:run`) but these failed in this environment due to registry/proxy `403` and missing binaries, so local builds/tests could not be executed (failures recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698619cd6bc08320a2e7d21bf3c27469)