### PR TITLE
fix: trim Clerk domain env var to prevent CSP header crash

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -21,6 +21,7 @@ const isProtectedRoute = createRouteMatcher([
 ])
 
 const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN?.trim() || ''
 const isDev = process.env.NODE_ENV === 'development'
 const isProduction = process.env.NODE_ENV === 'production'
 const suppressAuthWarning =
@@ -81,7 +82,7 @@ function buildCspHeader(nonce: string): string {
       'https://*.clerk.accounts.dev',
       'https://cdn.clerk.io',
       'https://*.clerk.com',
-      process.env.NEXT_PUBLIC_CLERK_DOMAIN ? `https://${process.env.NEXT_PUBLIC_CLERK_DOMAIN}` : '',
+      clerkDomain ? `https://${clerkDomain}` : '',
       'https://challenges.cloudflare.com',
     ]
       .filter(Boolean)
@@ -103,8 +104,8 @@ function buildCspHeader(nonce: string): string {
       'https://*.clerk.accounts.dev',
       'https://api.clerk.io',
       'https://*.clerk.com',
-      process.env.NEXT_PUBLIC_CLERK_DOMAIN ? `https://${process.env.NEXT_PUBLIC_CLERK_DOMAIN}` : '',
-      process.env.NEXT_PUBLIC_CLERK_DOMAIN ? `wss://${process.env.NEXT_PUBLIC_CLERK_DOMAIN}` : '',
+      clerkDomain ? `https://${clerkDomain}` : '',
+      clerkDomain ? `wss://${clerkDomain}` : '',
       isDev ? 'ws://localhost:* wss://localhost:*' : '',
       process.env.NEXT_PUBLIC_API_URL || '',
     ]
@@ -115,7 +116,7 @@ function buildCspHeader(nonce: string): string {
       "frame-src 'self'",
       'https://*.clerk.accounts.dev',
       'https://*.clerk.com',
-      process.env.NEXT_PUBLIC_CLERK_DOMAIN ? `https://${process.env.NEXT_PUBLIC_CLERK_DOMAIN}` : '',
+      clerkDomain ? `https://${clerkDomain}` : '',
       'https://challenges.cloudflare.com',
     ].filter(Boolean).join(' '),
     "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary

- Trims `NEXT_PUBLIC_CLERK_DOMAIN` at read time to strip trailing newlines
- The env var was stored with a `\n` via CLI pipe, causing `Headers.set TypeError` on Vercel (HTTP headers cannot contain newlines)
- Root cause of the 500 errors on all pages after the CSP changes

## Root cause

```
Error running the exported Web Handler: TypeError: Headers.set: "...https://clerk.lscaturchio.xyz\n https://challenges.cloudflare.com..."
```

## Verification

- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:run` — 185/185 pass
- [x] `bun run build` — clean
- [x] Local prod server — all pages return 200, CSP header has no newlines
- [ ] Vercel preview deployment — verify no 500s

## Test plan

- [ ] Visit preview URL homepage — should show React homepage (not old static HTML)
- [ ] Visit /pricing — should render
- [ ] Check response headers for clean CSP (no newlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)