### PR TITLE
fix(a11y): restore banner/contentinfo landmarks on all remaining pages

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -54,8 +54,9 @@ export default function Home(): React.ReactElement {
   const isClerkConfigured = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
   return (
-    <main className="min-h-screen">
+    <>
       <SiteHeader />
+      <main className="min-h-screen">
 
       {/* ----------------------------------------------------------------- */}
       {/* Hero Section                                                      */}
@@ -373,8 +374,9 @@ export default function Home(): React.ReactElement {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/analytics/AnalyticsPageClient.tsx
+++ b/apps/web/app/analytics/AnalyticsPageClient.tsx
@@ -93,8 +93,9 @@ function useAnalyticsPageView() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -280,8 +281,9 @@ function useAnalyticsPageView() {
         )}
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -14,8 +14,9 @@ export default function AuthPage() {
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
 
       <section className="py-14 sm:py-20">
         <div className="max-w-lg mx-auto px-4 sm:px-6 lg:px-8">
@@ -32,7 +33,8 @@ export default function AuthPage() {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -28,8 +28,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
 
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -60,8 +61,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         )}
       </article>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -12,8 +12,9 @@ export default async function BlogIndexPage() {
   const posts = await loadBlogPosts()
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
 
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -62,8 +63,9 @@ export default async function BlogIndexPage() {
         )}
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/brand/BrandPageClient.tsx
+++ b/apps/web/app/brand/BrandPageClient.tsx
@@ -176,11 +176,11 @@ function useBrandPageView() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
+      <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
       {/* Confirm Modal */}
       <ConfirmModalComponent />
-
-      <SiteHeader />
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -434,8 +434,9 @@ function useBrandPageView() {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/brand/score/ScorePageClient.tsx
+++ b/apps/web/app/brand/score/ScorePageClient.tsx
@@ -108,8 +108,9 @@ function useScorePage() {
   const canScore = !!selectedProfileId && content.trim().length > 0 && !isScoring
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -369,8 +370,9 @@ function useScorePage() {
         </m.div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/bulk/BulkGenerationPageClient.tsx
+++ b/apps/web/app/bulk/BulkGenerationPageClient.tsx
@@ -435,8 +435,9 @@ function useBulkGenerationPageView() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -1064,8 +1065,9 @@ function useBulkGenerationPageView() {
         </div>
       </div>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/history/HistoryPageClient.tsx
+++ b/apps/web/app/history/HistoryPageClient.tsx
@@ -145,8 +145,9 @@ function useHistoryPageView() {
   }, [fetchHistory])
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -369,8 +370,9 @@ function useHistoryPageView() {
         )}
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/pricing/PricingPageClient.tsx
+++ b/apps/web/app/pricing/PricingPageClient.tsx
@@ -235,8 +235,9 @@ export default function PricingPage() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white py-16">
@@ -588,7 +589,8 @@ export default function PricingPage() {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }

--- a/apps/web/app/templates/TemplatesPageClient.tsx
+++ b/apps/web/app/templates/TemplatesPageClient.tsx
@@ -11,8 +11,9 @@ import {
 
 export default function TemplatesPageClient() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -98,7 +99,8 @@ export default function TemplatesPageClient() {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }

--- a/apps/web/app/tools/ToolsPageClient.tsx
+++ b/apps/web/app/tools/ToolsPageClient.tsx
@@ -19,8 +19,9 @@ function ToolsPageContent() {
   }, [])
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
       {/* Hero Section */}
       <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
@@ -103,8 +104,9 @@ function ToolsPageContent() {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/app/tools/category/[category]/page.tsx
+++ b/apps/web/app/tools/category/[category]/page.tsx
@@ -49,8 +49,9 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
   const tools = await loadTools(categoryId)
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
+    <>
       <SiteHeader />
+      <main className="min-h-screen bg-gradient-to-b from-neutral-50 via-white to-neutral-100">
 
       <header className="border-b border-neutral-200 bg-white">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -125,8 +126,9 @@ export default async function ToolCategoryPage({ params }: CategoryPageProps) {
         </div>
       </section>
 
+      </main>
       <SiteFooter />
-    </main>
+    </>
   )
 }
 

--- a/apps/web/e2e/landmarks.spec.ts
+++ b/apps/web/e2e/landmarks.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Landmark regression guard.
+ *
+ * SiteHeader/SiteFooter must be siblings of <main>, not children: a <header>
+ * nested inside <main> loses its implicit `banner` role (same for <footer> /
+ * `contentinfo`), which breaks assistive-tech navigation. This swept the whole
+ * app once; these checks keep the public pages honest.
+ */
+// Limited to pages already exercised by the E2E suite (render reliably in the
+// no-backend E2E environment); the underlying fix was applied to all 16 pages.
+const PUBLIC_PAGES = ['/', '/pricing']
+
+for (const path of PUBLIC_PAGES) {
+  test(`page ${path} exposes banner and contentinfo landmarks`, async ({
+    page,
+  }) => {
+    await page.goto(path)
+    await expect(page.getByRole('banner')).toBeVisible()
+    await expect(page.getByRole('contentinfo')).toBeVisible()
+  })
+}

--- a/docs/REMEDIATION_PLAN.md
+++ b/docs/REMEDIATION_PLAN.md
@@ -31,7 +31,7 @@ gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
 |---|------|--------|
 | 2.1 | Ratchet coverage up toward 70/85 as tests land | ONGOING |
 | 2.2 | Backfill money/security paths (payments, Stripe webhooks, SSO, quotas) | IN PROGRESS — subscription routes (33%→89%) + webhook HMAC tests landed in #103; SSO identity mappers (SAML 19%→36%, OIDC 19%→37%) this PR. Next: webhook delivery/storage, reconcile path. |
-| 2.3 | Accessibility sweep: header/footer as siblings of `<main>` repo-wide + landmark checks | IN PROGRESS (3 pages done in #102) |
+| 2.3 | Accessibility sweep: header/footer as siblings of `<main>` repo-wide + landmark checks | DONE — remaining 13 pages restructured (16/16 total incl. #102's 3); `e2e/landmarks.spec.ts` regression guard added |
 
 ### Phase 3 — Finish the structural refactors (with nets)
 | # | Item | Status |


### PR DESCRIPTION
## Summary

Completes Phase 2.3 of `docs/REMEDIATION_PLAN.md`: the repo-wide accessibility landmark sweep started in #102.

**The bug:** nesting `<SiteHeader>`/`<SiteFooter>` inside `<main>` strips their implicit `banner`/`contentinfo` ARIA roles (per the HTML spec, `<header>`/`<footer>` only get those roles when not scoped to a sectioning element), which breaks assistive-tech landmark navigation. This was the root cause of the E2E failures fixed for 3 pages in #102 — but 13 more pages had the same structure.

## Changes
- **13 pages restructured** so header/footer are siblings of `<main>`: home, analytics, auth, blog index + post, brand, brand/score, bulk, history, pricing, templates, tools, tools/category. (privacy/terms were already correct; sign-in/sign-up/tool-directory were fixed in #102 — all 16 `SiteHeader` pages are now consistent.)
- **`e2e/landmarks.spec.ts`** added as a regression guard, asserting `banner` + `contentinfo` are visible on the pages the E2E suite already exercises (`/`, `/pricing`).

Applied via a uniform scripted transform (verified no page still nests the header), with one manual case (`ToolsPageClient`, which has a second `<main>` in its Suspense fallback).

## Verification
- Locally: `tsc` clean, `eslint` clean, all 192 Vitest tests pass, post-transform scan confirms zero remaining nested headers.
- Playwright cannot run in this sandbox (browser CDN blocked by the environment's network policy), so the **E2E verdict comes from this PR's CI run** — the identical transform passed CI E2E for the 3 pages in #102.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_