### PR TITLE
docs+ci: reconcile docs with reality; group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
         dependency-type: "development"
       production-dependencies:
         dependency-type: "production"
+      # Batch security fixes into a single PR so they can't be starved by the
+      # low version-update PR limit and the CVE backlog can't silently rebuild
+      # (see docs/REMEDIATION_PLAN.md Phase 4.1).
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   # Frontend JavaScript dependencies
   - package-ecosystem: "npm"
@@ -23,6 +30,10 @@ updates:
         dependency-type: "development"
       production-dependencies:
         dependency-type: "production"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The product is positioned around repeatable publishing, not generic prompt-box o
 - Bun-first frontend workflow with a committed `bun.lock`
 - Next.js 16 web app with React 18, Clerk, and Sentry
 - FastAPI backend with Neon/Postgres, Stripe, and quota-based product logic
-- Static marketing homepage at `/` for maximum Lighthouse performance
-- Verified Lighthouse `100 / 100 / 100 / 100`
-- Verified React Doctor `100 / 100`
+- Blocking CI: full backend pytest suite, frontend lint/type/unit/E2E, and a
+  dependency-audit gate that fails on any high/critical advisory
+- Coverage measured honestly (`all: true`) with ratchet floors that only move up
 
 ## Quick Start
 
@@ -143,12 +143,16 @@ blog-AI/
 
 ## Quality Bar
 
-- `bun run build` passes
-- `bun run audit:runtime` passes
-- Lighthouse on `/`: `100 / 100 / 100 / 100`
-- React Doctor: `100 / 100`
+Enforced by CI on every PR (see `.github/workflows/ci.yml`):
+
+- `bun run lint`, `bun run type-check`, and `bun run build` pass
+- Vitest unit suite passes with coverage at or above the ratchet floor
+- Playwright E2E suite passes
+- Full backend pytest suite passes (blocking), plus per-route coverage gates
+- `bun run audit:runtime` passes — zero unallowlisted high/critical advisories
 
 ## Notes
 
-- The landing page is served from `apps/web/public/home.html` through a rewrite in `apps/web/next.config.mjs` to keep `/` extremely fast.
+- The React homepage is rendered by `HomePageClient` at `/` (a previous
+  static `home.html` rewrite was removed; see git history).
 - Dependabot still uses the GitHub `npm` ecosystem for `apps/web`, but day-to-day development and CI now run through Bun.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,5 +1,14 @@
 # Database Schema Documentation
 
+> **⚠️ ACCURACY WARNING:** The migration inventory below describes
+> `supabase/migrations/`, but **nothing currently applies those files** — the
+> only automated runner (`bun run db:migrate`) applies `db/migrations/`, and
+> several tables are additionally created by runtime DDL in the API. The four
+> schema sources are divergent. Until the consolidation lands, treat
+> [`SCHEMA_AUDIT.md`](./SCHEMA_AUDIT.md) as the authoritative description of
+> how schema is actually produced, and do **not** use this document to
+> provision a new environment.
+
 This document provides comprehensive documentation of the Blog AI database schema, including all tables, relationships, indexes, and Row Level Security (RLS) policies.
 
 ## Table of Contents

--- a/docs/REMEDIATION_PLAN.md
+++ b/docs/REMEDIATION_PLAN.md
@@ -43,8 +43,8 @@ gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
 ### Phase 4 — Keep it honest (durable hygiene)
 | # | Item | Status |
 |---|------|--------|
-| 4.1 | Dependency automation (Dependabot grouping) so the CVE backlog can't silently rebuild | TODO |
-| 4.2 | Docs-vs-reality reconciliation (`DATABASE.md`, drop unverified "100/100" claims) | TODO |
+| 4.1 | Dependency automation (Dependabot grouping) so the CVE backlog can't silently rebuild | DONE — security updates now grouped into a single batched PR for pip + npm |
+| 4.2 | Docs-vs-reality reconciliation (`DATABASE.md`, drop unverified "100/100" claims) | DONE — README claims replaced with CI-enforced quality bar (dropped unverified Lighthouse/React-Doctor scores + stale home.html note); `DATABASE.md` carries an accuracy warning pointing to `SCHEMA_AUDIT.md` until the P0.1 consolidation lands |
 | 4.3 | Re-enable branch protection once `main` is genuinely green | NEEDS-OWNER |
 
 ---


### PR DESCRIPTION
## Summary

Phase 4.1 + 4.2 of `docs/REMEDIATION_PLAN.md` — durable honesty hygiene. Docs/config only; no runtime code changes.

## 4.2 Docs-vs-reality reconciliation
- **README**: the "Verified Lighthouse `100/100/100/100`" and "React Doctor `100/100`" claims were not verified by anything in CI — replaced with the quality bar CI *actually enforces* (blocking backend suite, lint/type/build, coverage ratchet floors, E2E, and the zero-high/critical dependency-audit gate). Also removed the stale note claiming `/` is served from `public/home.html` via a rewrite — that rewrite was removed in `52e6c07`.
- **`docs/DATABASE.md`**: added a prominent accuracy warning — the migration inventory it documents (`supabase/migrations/`) is applied by **no runner** (only `db/migrations/` is), and the four schema sources are divergent. Points readers to `docs/SCHEMA_AUDIT.md` until the staging-gated P0.1 consolidation lands, and warns against using it to provision a new environment.

## 4.1 Dependabot security grouping
- `dependabot.yml`: security updates for **pip** and **npm** are now batched into a single grouped PR each. Previously, security fixes competed with version bumps under `open-pull-requests-limit: 2` — exactly how the 25-advisory backlog (closed in #102) accumulated silently. Grouping makes the security batch one mergeable unit that can't be starved.

## Verification
- `dependabot.yml` validated as YAML; docs changes verified by inspection against git history (`52e6c07`) and the CI workflow definitions.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_