### PR TITLE
refactor(api): split batch export into its own router, with route tests first

### DIFF
--- a/apps/api/app/routes/__init__.py
+++ b/apps/api/app/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from .analytics import router as analytics_router
 from .batch import router as batch_router
+from .batch_export import router as batch_export_router
 from .blog import router as blog_router
 from .book import router as book_router
 from .brand_voice import router as brand_voice_router
@@ -36,6 +37,7 @@ from .zapier import router as zapier_router
 __all__ = [
     "analytics_router",
     "batch_router",
+    "batch_export_router",
     "blog_router",
     "book_router",
     "brand_voice_router",

--- a/apps/api/app/routes/batch.py
+++ b/apps/api/app/routes/batch.py
@@ -18,11 +18,8 @@ Authorization:
 
 import asyncio
 import csv
-import io
-import json
 import logging
 import uuid
-import zipfile
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -36,23 +33,18 @@ from fastapi import (
     UploadFile,
     status,
 )
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import Response
 
 from src.brand.storage import get_brand_voice_storage
 from src.config import get_settings
 from src.organizations import AuthorizationContext
 from src.storage import get_batch_job_store
 from src.types.batch import (
-    ALLOWED_PROVIDERS,
     BatchItemInput,
     CostEstimate,
-    CSVExportRow,
-    CSVImportRow,
     EnhancedBatchItemResult,
     EnhancedBatchRequest,
     EnhancedBatchStatus,
-    ExportFormat,
-    JobPriority,
     JobStatus,
     ProviderStrategy,
     RetryRequest,
@@ -71,7 +63,6 @@ from ..dependencies import (
 )
 from ..error_handlers import sanitize_error_message
 from ..middleware import require_pro_tier
-from ..storage import conversations
 from ..websocket import manager
 
 logger = logging.getLogger(__name__)
@@ -541,239 +532,6 @@ async def get_csv_template() -> Response:
         content=CSV_TEMPLATE,
         media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=batch_template.csv"},
-    )
-
-
-@router.get("/export/{job_id}")
-async def export_batch_results(
-    job_id: str,
-    format: ExportFormat = Query(default=ExportFormat.JSON),
-    auth_ctx: AuthorizationContext = Depends(require_content_access),
-) -> Response:
-    """
-    Export batch results in various formats.
-
-    Formats:
-    - json: Full JSON with all metadata
-    - csv: Tabular format with key fields
-    - markdown: Human-readable markdown
-    - zip: All content as individual files
-
-    **Authorization:** Requires content.view permission in the organization.
-    """
-    # Use organization_id for scoping if available, fallback to user_id
-    scope_id = auth_ctx.organization_id or auth_ctx.user_id
-    job = await _job_store.get_job_if_owned(job_id, scope_id)
-    if not job:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Job {job_id} not found or access denied",
-        )
-    if job.status not in [JobStatus.COMPLETED, JobStatus.PARTIAL, JobStatus.FAILED]:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Job {job_id} is still processing",
-        )
-
-    results = await _job_store.get_results(job_id)
-
-    if format == ExportFormat.JSON:
-        export_data = {
-            "job_id": job_id,
-            "job_name": job.name,
-            "status": job.status.value,
-            "total_items": job.total_items,
-            "completed_items": job.completed_items,
-            "failed_items": job.failed_items,
-            "total_cost_usd": job.actual_cost_usd,
-            "total_tokens": job.total_tokens_used,
-            "providers_used": job.providers_used,
-            "created_at": job.created_at,
-            "completed_at": job.completed_at,
-            "results": [r.model_dump() for r in results],
-        }
-        return Response(
-            content=json.dumps(export_data, indent=2),
-            media_type="application/json",
-            headers={
-                "Content-Disposition": f"attachment; filename=batch_{job_id}.json"
-            },
-        )
-
-    elif format == ExportFormat.CSV:
-        # Import CSV sanitization for formula injection protection
-        try:
-            from app.validators import sanitize_csv_field
-        except ImportError:
-            # Fallback sanitization if validators not available
-            def sanitize_csv_field(v):
-                if not v:
-                    return v
-                v = str(v)
-                if v and v[0] in {"=", "+", "-", "@", "\t", "\r", "\n"}:
-                    return f"'{v}"
-                return v
-
-        output = io.StringIO()
-        writer = csv.writer(output)
-        writer.writerow(
-            [
-                "index",
-                "topic",
-                "status",
-                "title",
-                "word_count",
-                "provider",
-                "execution_time_ms",
-                "cost_usd",
-                "error",
-            ]
-        )
-
-        for result in results:
-            title = ""
-            word_count = 0
-            if result.content:
-                title = result.content.get("title", "")
-                word_count = result.content.get("word_count", 0)
-
-            # Sanitize string fields to prevent CSV formula injection
-            writer.writerow(
-                [
-                    result.index,
-                    sanitize_csv_field(result.topic),
-                    result.status.value,
-                    sanitize_csv_field(title),
-                    word_count,
-                    result.provider_used or "",
-                    result.execution_time_ms,
-                    result.cost_usd,
-                    sanitize_csv_field(result.error or ""),
-                ]
-            )
-
-        return Response(
-            content=output.getvalue(),
-            media_type="text/csv",
-            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.csv"},
-        )
-
-    elif format == ExportFormat.MARKDOWN:
-        lines = [
-            f"# Batch Generation Results",
-            f"",
-            f"**Job ID:** {job_id}",
-            f"**Status:** {job.status.value}",
-            f"**Total Items:** {job.total_items}",
-            f"**Completed:** {job.completed_items}",
-            f"**Failed:** {job.failed_items}",
-            f"**Total Cost:** ${job.actual_cost_usd:.4f}",
-            f"**Completed At:** {job.completed_at}",
-            f"",
-            f"---",
-            f"",
-        ]
-
-        for result in results:
-            status_icon = "✅" if result.status == JobStatus.COMPLETED else "❌"
-            lines.append(f"## {status_icon} {result.index + 1}. {result.topic}")
-            lines.append(f"")
-
-            if result.status == JobStatus.COMPLETED and result.content:
-                lines.append(f"**Title:** {result.content.get('title', 'N/A')}")
-                lines.append(f"**Provider:** {result.provider_used}")
-                lines.append(f"**Word Count:** {result.content.get('word_count', 0)}")
-                lines.append(f"**Cost:** ${result.cost_usd:.4f}")
-                lines.append(f"")
-
-                # Add content preview
-                if result.content.get("sections"):
-                    lines.append(f"### Content Preview")
-                    for section in result.content["sections"][:2]:  # First 2 sections
-                        lines.append(f"")
-                        lines.append(f"#### {section['title']}")
-                        for subtopic in section.get("subtopics", [])[
-                            :1
-                        ]:  # First subtopic
-                            preview = subtopic.get("content", "")[:500]
-                            if len(subtopic.get("content", "")) > 500:
-                                preview += "..."
-                            lines.append(f"")
-                            lines.append(f"**{subtopic['title']}**")
-                            lines.append(f"")
-                            lines.append(preview)
-            else:
-                lines.append(f"**Error:** {result.error}")
-
-            lines.append(f"")
-            lines.append(f"---")
-            lines.append(f"")
-
-        return Response(
-            content="\n".join(lines),
-            media_type="text/markdown",
-            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.md"},
-        )
-
-    elif format == ExportFormat.ZIP:
-        # Create ZIP with individual content files
-        zip_buffer = io.BytesIO()
-        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-            # Add summary JSON
-            summary = {
-                "job_id": job_id,
-                "status": job.status.value,
-                "total_items": job.total_items,
-                "completed_items": job.completed_items,
-                "total_cost_usd": job.actual_cost_usd,
-            }
-            zf.writestr("summary.json", json.dumps(summary, indent=2))
-
-            # Add individual content files
-            for result in results:
-                if result.status == JobStatus.COMPLETED and result.content:
-                    # Create markdown content
-                    content_lines = [
-                        f"# {result.content.get('title', result.topic)}",
-                        f"",
-                        f"*{result.content.get('description', '')}*",
-                        f"",
-                    ]
-
-                    for section in result.content.get("sections", []):
-                        content_lines.append(f"## {section['title']}")
-                        content_lines.append("")
-                        for subtopic in section.get("subtopics", []):
-                            content_lines.append(f"### {subtopic['title']}")
-                            content_lines.append("")
-                            content_lines.append(subtopic.get("content", ""))
-                            content_lines.append("")
-
-                    # Safe filename
-                    safe_topic = "".join(
-                        c if c.isalnum() or c in " -_" else "_" for c in result.topic
-                    )
-                    filename = f"{result.index + 1:03d}_{safe_topic[:50]}.md"
-                    zf.writestr(f"content/{filename}", "\n".join(content_lines))
-
-                elif result.error:
-                    error_content = f"# Error: {result.topic}\n\n{result.error}"
-                    safe_topic = "".join(
-                        c if c.isalnum() or c in " -_" else "_" for c in result.topic
-                    )
-                    filename = f"{result.index + 1:03d}_{safe_topic[:50]}_ERROR.txt"
-                    zf.writestr(f"errors/{filename}", error_content)
-
-        zip_buffer.seek(0)
-        return Response(
-            content=zip_buffer.getvalue(),
-            media_type="application/zip",
-            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.zip"},
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail=f"Unknown export format: {format}",
     )
 
 

--- a/apps/api/app/routes/batch_export.py
+++ b/apps/api/app/routes/batch_export.py
@@ -1,0 +1,259 @@
+"""
+Batch results export endpoints.
+
+Serves completed batch results in JSON / CSV / Markdown / ZIP formats.
+Split out of app/routes/batch.py so the lifecycle router stays focused
+(docs/REMEDIATION_PLAN.md Phase 3.2 / P2.3). Same /batch prefix; route paths
+are unchanged.
+"""
+
+import csv
+import io
+import json
+import zipfile
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
+
+from src.organizations import AuthorizationContext
+from src.storage import get_batch_job_store
+from src.types.batch import ExportFormat, JobStatus
+
+from ..dependencies import require_content_access
+
+router = APIRouter(prefix="/batch", tags=["batch"])
+
+_job_store = get_batch_job_store()
+
+
+@router.get("/export/{job_id}")
+async def export_batch_results(
+    job_id: str,
+    format: ExportFormat = Query(default=ExportFormat.JSON),
+    auth_ctx: AuthorizationContext = Depends(require_content_access),
+) -> Response:
+    """
+    Export batch results in various formats.
+
+    Formats:
+    - json: Full JSON with all metadata
+    - csv: Tabular format with key fields
+    - markdown: Human-readable markdown
+    - zip: All content as individual files
+
+    **Authorization:** Requires content.view permission in the organization.
+    """
+    # Use organization_id for scoping if available, fallback to user_id
+    scope_id = auth_ctx.organization_id or auth_ctx.user_id
+    job = await _job_store.get_job_if_owned(job_id, scope_id)
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job {job_id} not found or access denied",
+        )
+    if job.status not in [JobStatus.COMPLETED, JobStatus.PARTIAL, JobStatus.FAILED]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Job {job_id} is still processing",
+        )
+
+    results = await _job_store.get_results(job_id)
+
+    if format == ExportFormat.JSON:
+        export_data = {
+            "job_id": job_id,
+            "job_name": job.name,
+            "status": job.status.value,
+            "total_items": job.total_items,
+            "completed_items": job.completed_items,
+            "failed_items": job.failed_items,
+            "total_cost_usd": job.actual_cost_usd,
+            "total_tokens": job.total_tokens_used,
+            "providers_used": job.providers_used,
+            "created_at": job.created_at,
+            "completed_at": job.completed_at,
+            "results": [r.model_dump() for r in results],
+        }
+        return Response(
+            content=json.dumps(export_data, indent=2),
+            media_type="application/json",
+            headers={
+                "Content-Disposition": f"attachment; filename=batch_{job_id}.json"
+            },
+        )
+
+    elif format == ExportFormat.CSV:
+        # Import CSV sanitization for formula injection protection
+        try:
+            from app.validators import sanitize_csv_field
+        except ImportError:
+            # Fallback sanitization if validators not available
+            def sanitize_csv_field(v):
+                if not v:
+                    return v
+                v = str(v)
+                if v and v[0] in {"=", "+", "-", "@", "\t", "\r", "\n"}:
+                    return f"'{v}"
+                return v
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            [
+                "index",
+                "topic",
+                "status",
+                "title",
+                "word_count",
+                "provider",
+                "execution_time_ms",
+                "cost_usd",
+                "error",
+            ]
+        )
+
+        for result in results:
+            title = ""
+            word_count = 0
+            if result.content:
+                title = result.content.get("title", "")
+                word_count = result.content.get("word_count", 0)
+
+            # Sanitize string fields to prevent CSV formula injection
+            writer.writerow(
+                [
+                    result.index,
+                    sanitize_csv_field(result.topic),
+                    result.status.value,
+                    sanitize_csv_field(title),
+                    word_count,
+                    result.provider_used or "",
+                    result.execution_time_ms,
+                    result.cost_usd,
+                    sanitize_csv_field(result.error or ""),
+                ]
+            )
+
+        return Response(
+            content=output.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.csv"},
+        )
+
+    elif format == ExportFormat.MARKDOWN:
+        lines = [
+            f"# Batch Generation Results",
+            f"",
+            f"**Job ID:** {job_id}",
+            f"**Status:** {job.status.value}",
+            f"**Total Items:** {job.total_items}",
+            f"**Completed:** {job.completed_items}",
+            f"**Failed:** {job.failed_items}",
+            f"**Total Cost:** ${job.actual_cost_usd:.4f}",
+            f"**Completed At:** {job.completed_at}",
+            f"",
+            f"---",
+            f"",
+        ]
+
+        for result in results:
+            status_icon = "✅" if result.status == JobStatus.COMPLETED else "❌"
+            lines.append(f"## {status_icon} {result.index + 1}. {result.topic}")
+            lines.append(f"")
+
+            if result.status == JobStatus.COMPLETED and result.content:
+                lines.append(f"**Title:** {result.content.get('title', 'N/A')}")
+                lines.append(f"**Provider:** {result.provider_used}")
+                lines.append(f"**Word Count:** {result.content.get('word_count', 0)}")
+                lines.append(f"**Cost:** ${result.cost_usd:.4f}")
+                lines.append(f"")
+
+                # Add content preview
+                if result.content.get("sections"):
+                    lines.append(f"### Content Preview")
+                    for section in result.content["sections"][:2]:  # First 2 sections
+                        lines.append(f"")
+                        lines.append(f"#### {section['title']}")
+                        for subtopic in section.get("subtopics", [])[
+                            :1
+                        ]:  # First subtopic
+                            preview = subtopic.get("content", "")[:500]
+                            if len(subtopic.get("content", "")) > 500:
+                                preview += "..."
+                            lines.append(f"")
+                            lines.append(f"**{subtopic['title']}**")
+                            lines.append(f"")
+                            lines.append(preview)
+            else:
+                lines.append(f"**Error:** {result.error}")
+
+            lines.append(f"")
+            lines.append(f"---")
+            lines.append(f"")
+
+        return Response(
+            content="\n".join(lines),
+            media_type="text/markdown",
+            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.md"},
+        )
+
+    elif format == ExportFormat.ZIP:
+        # Create ZIP with individual content files
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Add summary JSON
+            summary = {
+                "job_id": job_id,
+                "status": job.status.value,
+                "total_items": job.total_items,
+                "completed_items": job.completed_items,
+                "total_cost_usd": job.actual_cost_usd,
+            }
+            zf.writestr("summary.json", json.dumps(summary, indent=2))
+
+            # Add individual content files
+            for result in results:
+                if result.status == JobStatus.COMPLETED and result.content:
+                    # Create markdown content
+                    content_lines = [
+                        f"# {result.content.get('title', result.topic)}",
+                        f"",
+                        f"*{result.content.get('description', '')}*",
+                        f"",
+                    ]
+
+                    for section in result.content.get("sections", []):
+                        content_lines.append(f"## {section['title']}")
+                        content_lines.append("")
+                        for subtopic in section.get("subtopics", []):
+                            content_lines.append(f"### {subtopic['title']}")
+                            content_lines.append("")
+                            content_lines.append(subtopic.get("content", ""))
+                            content_lines.append("")
+
+                    # Safe filename
+                    safe_topic = "".join(
+                        c if c.isalnum() or c in " -_" else "_" for c in result.topic
+                    )
+                    filename = f"{result.index + 1:03d}_{safe_topic[:50]}.md"
+                    zf.writestr(f"content/{filename}", "\n".join(content_lines))
+
+                elif result.error:
+                    error_content = f"# Error: {result.topic}\n\n{result.error}"
+                    safe_topic = "".join(
+                        c if c.isalnum() or c in " -_" else "_" for c in result.topic
+                    )
+                    filename = f"{result.index + 1:03d}_{safe_topic[:50]}_ERROR.txt"
+                    zf.writestr(f"errors/{filename}", error_content)
+
+        zip_buffer.seek(0)
+        return Response(
+            content=zip_buffer.getvalue(),
+            media_type="application/zip",
+            headers={"Content-Disposition": f"attachment; filename=batch_{job_id}.zip"},
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Unknown export format: {format}",
+    )

--- a/apps/api/server.py
+++ b/apps/api/server.py
@@ -70,6 +70,7 @@ from app.middleware import (
 from app.routes import (
     analytics_router,
     batch_router,
+    batch_export_router,
     blog_router,
     book_router,
     brand_voice_router,
@@ -503,6 +504,7 @@ app.include_router(health_router)
 # Main API routes (at root level for backward compatibility)
 app.include_router(analytics_router)
 app.include_router(batch_router)
+app.include_router(batch_export_router)
 app.include_router(brand_voice_router)
 app.include_router(chat_router)
 app.include_router(content_router)
@@ -560,6 +562,7 @@ api_v1_router = APIRouter(prefix="/api/v1", tags=["v1"])
 # Add versioned routes
 api_v1_router.include_router(analytics_router)
 api_v1_router.include_router(batch_router)
+api_v1_router.include_router(batch_export_router)
 api_v1_router.include_router(brand_voice_router)
 api_v1_router.include_router(chat_router)
 api_v1_router.include_router(content_router)

--- a/apps/api/tests/test_routes_batch.py
+++ b/apps/api/tests/test_routes_batch.py
@@ -1,0 +1,237 @@
+"""
+Route-level tests for the batch generation endpoints (app/routes/batch.py).
+
+These are the characterization net required before the planned lifecycle/export
+router split (docs/REMEDIATION_PLAN.md Phase 3.2 / P2.3): they pin status
+codes, ownership scoping, state-gating, and response shapes for the endpoints
+the split must not change. Storage is mocked at the module-level _job_store;
+auth dependencies are overridden.
+"""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("DEV_API_KEY", "test-key")
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-mock-key-for-unit-tests-only")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+from src.types.batch import EnhancedBatchStatus, JobStatus
+
+AUTH_CTX = SimpleNamespace(user_id="user-1", organization_id=None)
+
+
+def make_job(**overrides) -> EnhancedBatchStatus:
+    defaults = dict(
+        job_id="job-1",
+        status=JobStatus.PROCESSING,
+        total_items=3,
+        completed_items=1,
+        failed_items=0,
+        can_cancel=True,
+    )
+    defaults.update(overrides)
+    return EnhancedBatchStatus(**defaults)
+
+
+class BatchRouteTestCase(unittest.TestCase):
+    """Shared client with auth dependencies overridden."""
+
+    def setUp(self):
+        from app.dependencies import require_content_access, require_content_creation
+        from app.middleware import require_pro_tier
+        from server import app
+
+        self.app = app
+        self._deps = [
+            require_content_access,
+            require_content_creation,
+            require_pro_tier,
+        ]
+        app.dependency_overrides[require_content_access] = lambda: AUTH_CTX
+        app.dependency_overrides[require_content_creation] = lambda: AUTH_CTX
+        app.dependency_overrides[require_pro_tier] = lambda: "user-1"
+        self.client = TestClient(app)
+        self.client.headers.update({"X-API-Key": "test-key"})
+
+    def tearDown(self):
+        for dep in self._deps:
+            self.app.dependency_overrides.pop(dep, None)
+
+
+class TestCsvTemplate(BatchRouteTestCase):
+    def test_template_downloads_as_csv(self):
+        resp = self.client.get("/batch/template/csv")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        assert "attachment" in resp.headers["content-disposition"]
+        # header row of the documented import format
+        assert resp.text.splitlines()[0] == (
+            "topic,keywords,tone,content_type,custom_instructions"
+        )
+
+
+class TestEstimate(BatchRouteTestCase):
+    ITEMS = [
+        {"topic": "AI in Healthcare", "keywords": ["ai"], "tone": "professional"},
+        {"topic": "Remote Work", "keywords": [], "tone": "casual"},
+    ]
+
+    def test_estimate_returns_cost_shape(self):
+        resp = self.client.post("/batch/estimate", json=self.ITEMS)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["estimated_cost_usd"] > 0
+        assert data["estimated_input_tokens"] > 0
+        assert data["estimated_output_tokens"] > 0
+        assert 0.0 <= data["confidence"] <= 1.0
+
+    def test_estimate_rejects_over_100_items(self):
+        # Topics must pass BatchItemInput validation (min 3 chars) so the
+        # request reaches the handler's own >100 cap check.
+        items = [
+            {"topic": f"Topic number {i}", "keywords": [], "tone": "casual"}
+            for i in range(101)
+        ]
+        resp = self.client.post("/batch/estimate", json=items)
+        assert resp.status_code == 400
+
+    def test_estimate_rejects_unknown_provider(self):
+        resp = self.client.post(
+            "/batch/estimate?preferred_provider=not-a-provider", json=self.ITEMS
+        )
+        assert resp.status_code == 400
+
+
+class TestJobStatus(BatchRouteTestCase):
+    def test_status_returns_owned_job(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(return_value=make_job())
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.get("/batch/job-1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["job_id"] == "job-1"
+        assert data["status"] == "processing"
+        # ownership scoping: called with the auth context's scope id
+        store.get_job_if_owned.assert_awaited_once_with("job-1", "user-1")
+
+    def test_status_404_when_not_owned_or_missing(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(return_value=None)
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.get("/batch/nope")
+        assert resp.status_code == 404
+
+
+class TestJobResults(BatchRouteTestCase):
+    def test_results_400_while_processing(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(
+            return_value=make_job(status=JobStatus.PROCESSING)
+        )
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.get("/batch/job-1/results")
+        assert resp.status_code == 400
+
+    def test_results_returned_for_completed_job(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(
+            return_value=make_job(
+                status=JobStatus.COMPLETED, completed_items=3, can_cancel=False
+            )
+        )
+        store.get_results = AsyncMock(return_value=[])
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.get("/batch/job-1/results")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["status"] == "completed"
+        assert data["results"] == []
+
+
+class TestCancel(BatchRouteTestCase):
+    def test_cancel_sets_flag_and_updates_status(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(return_value=make_job(can_cancel=True))
+        store.set_cancel_flag = AsyncMock()
+        store.update_job = AsyncMock()
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.post("/batch/job-1/cancel")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+        store.set_cancel_flag.assert_awaited_once_with("job-1", True)
+        store.update_job.assert_awaited_once_with(
+            "job-1", status=JobStatus.CANCELLED.value, can_cancel=False
+        )
+
+    def test_cancel_400_when_not_cancellable(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(
+            return_value=make_job(status=JobStatus.COMPLETED, can_cancel=False)
+        )
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.post("/batch/job-1/cancel")
+        assert resp.status_code == 400
+
+    def test_cancel_404_when_missing(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(return_value=None)
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.post("/batch/nope/cancel")
+        assert resp.status_code == 404
+
+
+class TestListJobs(BatchRouteTestCase):
+    def test_list_returns_pagination_shape(self):
+        jobs = [make_job(job_id=f"job-{i}") for i in range(3)]
+        store = MagicMock()
+        store.list_jobs = AsyncMock(side_effect=[jobs[:2], jobs])
+        with patch("app.routes.batch._job_store", store):
+            resp = self.client.get("/batch/jobs?limit=2&offset=0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["jobs"]) == 2
+        assert data["total"] == 3
+        assert data["has_more"] is True
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestExport(BatchRouteTestCase):
+    def test_export_json_for_completed_job(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(
+            return_value=make_job(status=JobStatus.COMPLETED, can_cancel=False)
+        )
+        store.get_results = AsyncMock(return_value=[])
+        with patch("app.routes.batch_export._job_store", store):
+            resp = self.client.get("/batch/export/job-1?format=json")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_export_400_while_processing(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(
+            return_value=make_job(status=JobStatus.PROCESSING)
+        )
+        with patch("app.routes.batch_export._job_store", store):
+            resp = self.client.get("/batch/export/job-1?format=json")
+        assert resp.status_code == 400
+
+    def test_export_404_when_missing(self):
+        store = MagicMock()
+        store.get_job_if_owned = AsyncMock(return_value=None)
+        with patch("app.routes.batch_export._job_store", store):
+            resp = self.client.get("/batch/export/nope?format=json")
+        assert resp.status_code == 404

--- a/docs/REMEDIATION_PLAN.md
+++ b/docs/REMEDIATION_PLAN.md
@@ -37,7 +37,7 @@ gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
 | # | Item | Status |
 |---|------|--------|
 | 3.1 | `BulkGenerationPageClient` — write bulk-flow component tests, then split the ~1,030-line hook/JSX | TODO |
-| 3.2 | `batch.py` router split (lifecycle vs export) — route tests first | TODO |
+| 3.2 | `batch.py` router split (lifecycle vs export) — route tests first | DONE — 15 route-level characterization tests added first (status/results/cancel/list/estimate/template/export incl. ownership scoping + state gating), then the 233-line export endpoint moved to `batch_export.py` (own router, same paths). batch.py 1312→834 overall |
 | 3.3 | Remaining 1,000+ line modules — test-net first | TODO |
 
 ### Phase 4 — Keep it honest (durable hygiene)
@@ -71,7 +71,7 @@ gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
 |----|------|--------|
 | P2.1 | `marketing_templates.py` (1944) → fields/categories/per-category modules | DONE — assembler is 42 lines; 7 category modules (≤369 lines); registry SHA verified identical |
 | P2.2 | `rate_limit.py` (1288) → backends/models/shared base | DONE — backends → `rate_limit_backends.py`; `RateLimiter`/`GenerationRateLimiter` deduped onto shared `_BaseRateLimiter` (1288→880 lines). 19 rate-limiter tests; full suite green |
-| P2.3 | `batch.py` (1312) → providers/item_processor/csv/lifecycle+export routers | PARTIAL — extracted `batch_providers.py` (6 tests), `batch_csv.py` (7 tests), and `batch_item_processor.py`; batch.py 1312→1076 lines. Remaining: lifecycle/export router split (needs route tests first) |
+| P2.3 | `batch.py` (1312) → providers/item_processor/csv/lifecycle+export routers | PARTIAL — extracted `batch_providers.py` (6 tests), `batch_csv.py` (7 tests), and `batch_item_processor.py`; batch.py 1312→1076 lines. Export router split DONE (see Phase 3.2); batch.py 1312→834 |
 | P2.4 | `BulkGenerationPageClient.tsx` (1164) → constants/csv/hooks/components | PARTIAL — extracted `constants.ts` + pure `csv.ts` (1164→1074 lines) + 7 vitest tests for parseCSV/createDraftItem. Remaining: split the page-view hook and the 600-line render into components |
 | P2.5 | `HomePageClient.tsx` (858) → data/animations/sections | DONE — extracted `_home/data.ts` + `_home/animations.ts` (858→622 lines) |
 


### PR DESCRIPTION
## Summary

Phase 3.2 of `docs/REMEDIATION_PLAN.md` — the last planned `batch.py` decomposition step, done **test-first**.

## 1. Route-level characterization net (written before the split)

`tests/test_routes_batch.py` — 15 tests pinning the behavior the split must not change:
- **template/csv**: content-type, attachment disposition, documented header row
- **estimate**: cost-shape fields, the handler's >100-item cap (400), unknown-provider rejection (400)
- **status / results / cancel / list**: ownership scoping (`get_job_if_owned` called with the auth context's scope id), 404 on missing/not-owned, 400 state gating (results while processing, cancel when `can_cancel=False`), cancel's store side-effects, list pagination shape
- **export**: JSON happy path, 400 while processing, 404 missing

Auth dependencies are overridden; storage is mocked at the module-level `_job_store`.

## 2. The split

The 233-line export endpoint (JSON/CSV/Markdown/ZIP rendering) moves from `batch.py` to **`batch_export.py`** with its own `/batch`-prefixed router, registered alongside the lifecycle router — **route paths unchanged**, verified by the same tests. Also removes the imports orphaned by the move plus the pre-existing unused ones (both modules are now ruff F401-clean).

`batch.py`: **1312 (start of effort) → 834 lines**, now purely lifecycle (create/import/estimate/retry/status/results/cancel/list) with providers, CSV parsing, and the item processor already in their own tested modules from #102.

## Verification
- All 15 new route tests pass before *and* after the split (same assertions, only the export tests' patch target moved with the code).
- Full backend `pytest` suite green (0 failures).

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_