### PR TITLE
test+refactor(web): bulk-page RTL net, begin section extraction, bump coverage ratchet

### DIFF
--- a/apps/web/app/bulk/BulkGenerationPageClient.tsx
+++ b/apps/web/app/bulk/BulkGenerationPageClient.tsx
@@ -40,6 +40,7 @@ import {
   EXPORT_OPTIONS,
 } from './constants'
 import { createDraftItem, parseCSV, type BulkDraftItem } from './csv'
+import { ActivationHint, BulkHero, WorkflowBanner } from './components/PageBanners'
 
 function useBulkGenerationPageView() {
   const [conversationId] = useState(() => uuidv4())
@@ -439,81 +440,17 @@ function useBulkGenerationPageView() {
       <SiteHeader />
       <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-950 dark:to-gray-900">
 
-      {/* Hero Section */}
-      <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <m.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            <h1 className="text-2xl sm:text-3xl font-bold mb-2">
-              Bulk SEO Content Workflow
-            </h1>
-            <p className="text-amber-100">
-              Queue multiple topics, compare provider cost, and generate campaign-ready drafts
-              faster than prompt-by-prompt writing.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-3 text-sm">
-              <span className="rounded-full bg-white/15 px-3 py-1">Best for publishing calendars</span>
-              <span className="rounded-full bg-white/15 px-3 py-1">Pairs with Brand Voice</span>
-              <span className="rounded-full bg-white/15 px-3 py-1">Strongest Pro workflow today</span>
-            </div>
-          </m.div>
-        </div>
-      </section>
+      <BulkHero />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {activationHint && (
-          <m.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-            className="mb-6 rounded-2xl border border-green-200 bg-green-50/80 p-5 text-sm text-green-900 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-100"
-          >
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <p>{activationHint}</p>
-              <button
-                type="button"
-                onClick={() => setActivationHint(null)}
-                className="rounded-lg border border-green-300 px-3 py-2 font-medium text-green-800 transition-colors hover:bg-green-100 dark:border-green-800 dark:text-green-200 dark:hover:bg-green-900/30"
-              >
-                Dismiss
-              </button>
-            </div>
-          </m.div>
+          <ActivationHint
+            hint={activationHint}
+            onDismiss={() => setActivationHint(null)}
+          />
         )}
 
-        <m.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.05 }}
-          className="mb-6 rounded-2xl border border-amber-200 bg-amber-50/80 p-5 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
-        >
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-            <div>
-              <p className="font-semibold">Recommended workflow</p>
-              <p className="mt-1 text-amber-800 dark:text-amber-200">
-                Create a brand profile first, then use bulk generation for repeatable SEO content
-                batches. That is the clearest upgrade path from free usage to a paid workflow.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/brand"
-                className="inline-flex items-center justify-center rounded-lg bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700"
-              >
-                Open Brand Voice
-              </Link>
-              <Link
-                href="/pricing"
-                className="inline-flex items-center justify-center rounded-lg border border-amber-300 px-4 py-2 font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-900/30"
-              >
-                Compare Plans
-              </Link>
-            </div>
-          </div>
-        </m.div>
+        <WorkflowBanner />
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Left Column - Items */}

--- a/apps/web/app/bulk/components/PageBanners.tsx
+++ b/apps/web/app/bulk/components/PageBanners.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+import { m } from 'framer-motion'
+
+/**
+ * Presentational banner sections for the bulk generation page, extracted from
+ * BulkGenerationPageClient as part of the Phase 3.1 split
+ * (docs/REMEDIATION_PLAN.md). Behavior pinned by
+ * tests/app/bulk/BulkGenerationPageClient.test.tsx.
+ */
+
+export function BulkHero() {
+  return (
+    <section className="bg-gradient-to-r from-amber-600 to-amber-700 text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <m.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          <h1 className="text-2xl sm:text-3xl font-bold mb-2">
+            Bulk SEO Content Workflow
+          </h1>
+          <p className="text-amber-100">
+            Queue multiple topics, compare provider cost, and generate campaign-ready drafts
+            faster than prompt-by-prompt writing.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm">
+            <span className="rounded-full bg-white/15 px-3 py-1">Best for publishing calendars</span>
+            <span className="rounded-full bg-white/15 px-3 py-1">Pairs with Brand Voice</span>
+            <span className="rounded-full bg-white/15 px-3 py-1">Strongest Pro workflow today</span>
+          </div>
+        </m.div>
+      </div>
+    </section>
+  )
+}
+
+export function ActivationHint({
+  hint,
+  onDismiss,
+}: {
+  hint: string
+  onDismiss: () => void
+}) {
+  return (
+    <m.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="mb-6 rounded-2xl border border-green-200 bg-green-50/80 p-5 text-sm text-green-900 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-100"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <p>{hint}</p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-lg border border-green-300 px-3 py-2 font-medium text-green-800 transition-colors hover:bg-green-100 dark:border-green-800 dark:text-green-200 dark:hover:bg-green-900/30"
+        >
+          Dismiss
+        </button>
+      </div>
+    </m.div>
+  )
+}
+
+export function WorkflowBanner() {
+  return (
+    <m.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.05 }}
+      className="mb-6 rounded-2xl border border-amber-200 bg-amber-50/80 p-5 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="font-semibold">Recommended workflow</p>
+          <p className="mt-1 text-amber-800 dark:text-amber-200">
+            Create a brand profile first, then use bulk generation for repeatable SEO content
+            batches. That is the clearest upgrade path from free usage to a paid workflow.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/brand"
+            className="inline-flex items-center justify-center rounded-lg bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700"
+          >
+            Open Brand Voice
+          </Link>
+          <Link
+            href="/pricing"
+            className="inline-flex items-center justify-center rounded-lg border border-amber-300 px-4 py-2 font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-900/30"
+          >
+            Compare Plans
+          </Link>
+        </div>
+      </div>
+    </m.div>
+  )
+}

--- a/apps/web/tests/app/bulk/BulkGenerationPageClient.test.tsx
+++ b/apps/web/tests/app/bulk/BulkGenerationPageClient.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BulkGenerationPageClient from '@/app/bulk/BulkGenerationPageClient'
+
+/**
+ * Characterization net for the bulk generation page ahead of the planned
+ * hook/JSX split (docs/REMEDIATION_PLAN.md Phase 3.1): pins the interactive
+ * shell — empty state, adding/removing topic rows, and the provider/strategy
+ * controls — so extractions can be verified against unchanged behavior.
+ */
+
+vi.mock('framer-motion', () => {
+  const passthrough = (tag: string) =>
+    function MockMotion({ children, ...props }: Record<string, unknown>) {
+      const Tag = tag as keyof JSX.IntrinsicElements
+      void props
+      return <Tag>{children as React.ReactNode}</Tag>
+    }
+  return {
+    m: new Proxy({}, { get: (_t, prop: string) => passthrough(prop) }),
+    motion: new Proxy({}, { get: (_t, prop: string) => passthrough(prop) }),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+vi.mock('../../../components/SiteHeader', () => ({
+  default: () => <header data-testid="site-header" />,
+}))
+vi.mock('../../../components/SiteFooter', () => ({
+  default: () => <footer data-testid="site-footer" />,
+}))
+
+vi.mock('../../../components/UsageIndicator', () => ({
+  default: () => <div data-testid="usage-indicator" />,
+  useUsageCheck: () => ({
+    canGenerate: true,
+    remaining: null,
+    loading: false,
+    checkUsage: vi.fn().mockResolvedValue(true),
+  }),
+}))
+
+vi.mock('../../../hooks/useLlmConfig', () => ({
+  useLlmConfig: () => ({
+    config: null,
+    availableProviders: ['openai', 'anthropic', 'gemini'],
+    defaultProvider: 'openai',
+  }),
+}))
+
+describe('BulkGenerationPageClient', () => {
+  beforeEach(() => {
+    vi.mocked(global.fetch).mockReset()
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+  })
+
+  it('renders the empty state with CSV/manual guidance', () => {
+    render(<BulkGenerationPageClient />)
+    expect(
+      screen.getByText(/upload a csv or add topics manually/i)
+    ).toBeInTheDocument()
+  })
+
+  it('adds a topic row when Add Topic is clicked', () => {
+    render(<BulkGenerationPageClient />)
+    expect(screen.queryAllByPlaceholderText(/enter topic/i)).toHaveLength(0)
+
+    fireEvent.click(screen.getByRole('button', { name: /add topic/i }))
+    expect(screen.getAllByPlaceholderText(/enter topic/i)).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /add topic/i }))
+    expect(screen.getAllByPlaceholderText(/enter topic/i)).toHaveLength(2)
+  })
+
+  it('edits a topic value through the input', () => {
+    render(<BulkGenerationPageClient />)
+    fireEvent.click(screen.getByRole('button', { name: /add topic/i }))
+    const input = screen.getByPlaceholderText(/enter topic/i)
+    fireEvent.change(input, { target: { value: 'AI in Healthcare' } })
+    expect(input).toHaveValue('AI in Healthcare')
+  })
+
+  it('shows the provider strategy options', () => {
+    render(<BulkGenerationPageClient />)
+    expect(screen.getByText(/single provider/i)).toBeInTheDocument()
+    expect(screen.getByText(/round robin/i)).toBeInTheDocument()
+  })
+
+  it('renders header and footer stubs (page shell intact)', () => {
+    render(<BulkGenerationPageClient />)
+    expect(screen.getByTestId('site-header')).toBeInTheDocument()
+    expect(screen.getByTestId('site-footer')).toBeInTheDocument()
+  })
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -52,10 +52,10 @@ export default defineConfig({
       // (see docs/REMEDIATION_PLAN.md P1.1/P1.2). Do NOT lower these to make a
       // red build green — add tests instead.
       thresholds: {
-        branches: 9,
-        functions: 10,
-        lines: 10,
-        statements: 10,
+        branches: 10,
+        functions: 11,
+        lines: 11,
+        statements: 11,
       },
     },
   },

--- a/docs/REMEDIATION_PLAN.md
+++ b/docs/REMEDIATION_PLAN.md
@@ -29,14 +29,14 @@ gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
 ### Phase 2 — Make the gauges tell the truth
 | # | Item | Status |
 |---|------|--------|
-| 2.1 | Ratchet coverage up toward 70/85 as tests land | ONGOING |
+| 2.1 | Ratchet coverage up toward 70/85 as tests land | ONGOING — frontend floor bumped 9-10% → 10-11% (real: ~12% lines) |
 | 2.2 | Backfill money/security paths (payments, Stripe webhooks, SSO, quotas) | IN PROGRESS — subscription routes (33%→89%) + webhook HMAC tests landed in #103; SSO identity mappers (SAML 19%→36%, OIDC 19%→37%) this PR. Next: webhook delivery/storage, reconcile path. |
 | 2.3 | Accessibility sweep: header/footer as siblings of `<main>` repo-wide + landmark checks | DONE — remaining 13 pages restructured (16/16 total incl. #102's 3); `e2e/landmarks.spec.ts` regression guard added |
 
 ### Phase 3 — Finish the structural refactors (with nets)
 | # | Item | Status |
 |---|------|--------|
-| 3.1 | `BulkGenerationPageClient` — write bulk-flow component tests, then split the ~1,030-line hook/JSX | TODO |
+| 3.1 | `BulkGenerationPageClient` — write bulk-flow component tests, then split the ~1,030-line hook/JSX | IN PROGRESS — 5-test RTL characterization net added; Hero/ActivationHint/WorkflowBanner extracted to `app/bulk/components/PageBanners.tsx` (page 1074→1012). Remaining sections (CSV panel, topics list, job panel) follow the same pinned pattern. |
 | 3.2 | `batch.py` router split (lifecycle vs export) — route tests first | DONE — 15 route-level characterization tests added first (status/results/cancel/list/estimate/template/export incl. ownership scoping + state gating), then the 233-line export endpoint moved to `batch_export.py` (own router, same paths). batch.py 1312→834 overall |
 | 3.3 | Remaining 1,000+ line modules — test-net first | TODO |
 


### PR DESCRIPTION
## Summary

Phase 3.1 (started) + Phase 2.1 of `docs/REMEDIATION_PLAN.md`, done in the established test-first order.

## 1. RTL characterization net (the prerequisite 3.1 demanded)
`tests/app/bulk/BulkGenerationPageClient.test.tsx` — 5 tests pinning the interactive shell with framer-motion/hook mocks: empty-state guidance, add-topic creates rows (×2), editing a topic input, provider-strategy options render, and the header/footer page shell.

## 2. First extraction under the net
The static **Hero**, the **ActivationHint** banner (hint + dismiss), and the static **WorkflowBanner** move to `app/bulk/components/PageBanners.tsx`. Page: **1074 → 1012 lines**. This establishes the pinned pattern for the remaining sections (CSV panel, topics list, job panel) — tracked in the plan.

## 3. Coverage ratchet bump (Phase 2.1)
Real totals rose to **~12% lines / 10.2% branches** (was ~10/9 at the last bump) from this PR's tests plus the recent backend-test PRs' frontend siblings. Floors bumped **9–10% → 10–11%**; gate verified passing at the new floor. Per policy, floors only move up.

## Verification
tsc clean, eslint clean, **197/197** unit tests pass, coverage gate green at the bumped floor.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_