### PR TITLE
fix(web): repair CSV bulk-import round-trip, gate KB nav link, fix /auth dead-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,6 +261,12 @@ ENABLE_BUSINESS_TIER=false
 # them during blog generation.  Uses pgvector on Neon by default.
 ENABLE_KNOWLEDGE_BASE=false
 
+# [OPTIONAL] Frontend mirror of the flag above. The web app only shows the
+# "Knowledge Base" nav link when this is "true". Keep it in sync with
+# ENABLE_KNOWLEDGE_BASE so the UI never advertises a route the backend rejects.
+# This belongs in apps/web/.env.local (it is a NEXT_PUBLIC_ build-time flag).
+# NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE=false
+
 # [OPTIONAL] Vector store provider (default: pgvector — uses DATABASE_URL)
 # Options: pgvector (recommended), chromadb (local dev), pinecone
 # KB_VECTOR_STORE=pgvector

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import SiteFooter from '../../components/SiteFooter'
 import SiteHeader from '../../components/SiteHeader'
 import { SignIn } from '../../lib/clerk-ui'
@@ -24,10 +25,25 @@ export default function AuthPage() {
             {publishableKey ? (
               <SignIn routing="path" path="/auth" signUpUrl="/sign-up" />
             ) : (
-              <p className="text-sm text-gray-600">
-                Clerk is not configured. Set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and
-                `CLERK_SECRET_KEY` to enable sign-in.
-              </p>
+              <div className="text-center space-y-4">
+                <h1 className="text-xl font-semibold text-gray-900">
+                  No sign-in required
+                </h1>
+                <p className="text-sm text-gray-600">
+                  This deployment runs without authentication, so the full
+                  workspace is open. Jump straight in — no account needed.
+                </p>
+                <Link
+                  href="/generate"
+                  className="inline-flex items-center justify-center rounded-lg bg-amber-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-amber-700"
+                >
+                  Open the workspace
+                </Link>
+                <p className="text-xs text-gray-400">
+                  To require accounts, set <code>NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY</code>{' '}
+                  and <code>CLERK_SECRET_KEY</code>.
+                </p>
+              </div>
             )}
           </div>
         </div>

--- a/apps/web/app/bulk/BulkGenerationPageClient.tsx
+++ b/apps/web/app/bulk/BulkGenerationPageClient.tsx
@@ -264,7 +264,9 @@ function useBulkGenerationPageView() {
         const newItems: BulkDraftItem[] = rows.map((row) =>
           createDraftItem(
             row.topic,
-            row.keywords ? row.keywords.split(';').map((k) => k.trim()) : [],
+            row.keywords
+              ? row.keywords.split(',').map((k) => k.trim()).filter(Boolean)
+              : [],
             row.tone || sharedTone
           )
         )
@@ -425,7 +427,7 @@ function useBulkGenerationPageView() {
 
   // Download CSV template
   const downloadTemplate = () => {
-    const template = 'topic,keywords,tone\n"Example blog topic","keyword1;keyword2;keyword3","informative"\n"Another topic","seo;marketing","professional"'
+    const template = 'topic,keywords,tone\n"Example blog topic","keyword1,keyword2,keyword3","informative"\n"Another topic","seo,marketing","professional"'
     const blob = new Blob([template], { type: 'text/csv' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')

--- a/apps/web/app/bulk/csv.ts
+++ b/apps/web/app/bulk/csv.ts
@@ -26,6 +26,42 @@ export function createDraftItem(
   }
 }
 
+// Parse a single CSV line into its fields, honoring double-quoted cells so that
+// commas inside quotes (e.g. a quoted keywords list) are not treated as field
+// separators. Escaped quotes ("") inside a quoted field collapse to a single ".
+export function parseCSVLine(line: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"'
+          i++ // skip the escaped quote
+        } else {
+          inQuotes = false
+        }
+      } else {
+        current += char
+      }
+    } else if (char === '"') {
+      inQuotes = true
+    } else if (char === ',') {
+      fields.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+
+  fields.push(current)
+  return fields.map((f) => f.trim())
+}
+
 export function parseCSV(csvText: string): ParsedCSVData {
   const lines = csvText.trim().split('\n')
   const errors: string[] = []
@@ -40,7 +76,7 @@ export function parseCSV(csvText: string): ParsedCSVData {
   if (!headerLine) {
     return { rows: [], errors: ['Empty CSV file'], headers: [] }
   }
-  const headers = headerLine.split(',').map((h) => h.trim().toLowerCase())
+  const headers = parseCSVLine(headerLine).map((h) => h.toLowerCase())
 
   const topicIndex = headers.indexOf('topic')
   const keywordsIndex = headers.indexOf('keywords')
@@ -56,8 +92,8 @@ export function parseCSV(csvText: string): ParsedCSVData {
     const line = lines[i]
     if (!line || !line.trim()) continue
 
-    // Simple CSV parsing (doesn't handle quoted commas)
-    const values = line.split(',').map((v) => v.trim())
+    // Quote-aware parsing so commas inside a quoted keywords cell survive.
+    const values = parseCSVLine(line)
 
     const topic = values[topicIndex]
     if (!topic) {

--- a/apps/web/components/SiteHeader.tsx
+++ b/apps/web/components/SiteHeader.tsx
@@ -10,7 +10,16 @@ interface NavLink {
   href: string
   label: string
   authRequired: boolean
+  /** When set, the link only appears if this build-time flag is enabled. */
+  flag?: boolean
 }
+
+// The Knowledge Base surface is gated behind a backend feature flag
+// (ENABLE_KNOWLEDGE_BASE, default off). Mirror that on the frontend with
+// NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE so we don't advertise a route that the
+// backend will reject. Defaults to off to match the backend.
+const knowledgeBaseEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE === 'true'
 
 const navLinks: NavLink[] = [
   { href: '/pricing', label: 'Pricing', authRequired: false },
@@ -19,12 +28,12 @@ const navLinks: NavLink[] = [
   { href: '/bulk', label: 'Bulk', authRequired: true },
   { href: '/generate', label: 'Generate', authRequired: true },
   { href: '/tools', label: 'Tools', authRequired: true },
-  { href: '/knowledge', label: 'Knowledge Base', authRequired: true },
+  { href: '/knowledge', label: 'Knowledge Base', authRequired: true, flag: knowledgeBaseEnabled },
   { href: '/templates', label: 'Templates', authRequired: true },
   { href: '/images', label: 'Images', authRequired: true },
   { href: '/social', label: 'Social', authRequired: true },
   { href: '/team', label: 'Team', authRequired: true },
-]
+].filter((link) => link.flag !== false)
 
 const publicLinks = navLinks.filter((link) => !link.authRequired)
 const authLinks = navLinks.filter((link) => link.authRequired)

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -22,11 +22,16 @@ test.describe('Knowledge Base page', () => {
     await expect(emptyState.or(docTable)).toBeVisible()
   })
 
-  test('should have Knowledge Base link in navigation', async ({ page }) => {
+  test('hides the Knowledge Base nav link when the feature flag is off', async ({
+    page,
+  }) => {
+    // The Knowledge Base backend ships flagged off (ENABLE_KNOWLEDGE_BASE=false),
+    // so the nav link is gated behind NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE, which is
+    // unset in the E2E environment. The header should not advertise the route.
     await page.goto('/')
-    const navLink = page.getByRole('link', { name: /knowledge base/i })
-    // Link may be in desktop or mobile nav
-    await expect(navLink.first()).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: /knowledge base/i })
+    ).toHaveCount(0)
   })
 })
 

--- a/apps/web/tests/app/bulk/csv.test.ts
+++ b/apps/web/tests/app/bulk/csv.test.ts
@@ -1,14 +1,34 @@
 import { describe, it, expect } from 'vitest'
-import { parseCSV, createDraftItem } from '@/app/bulk/csv'
+import { parseCSV, parseCSVLine, createDraftItem } from '@/app/bulk/csv'
 
 describe('parseCSV', () => {
   it('parses a well-formed CSV with topic, keywords, and tone', () => {
-    const result = parseCSV('topic,keywords,tone\nAI safety,llm;risk,professional')
+    const result = parseCSV('topic,keywords,tone\nAI safety,risk,professional')
     expect(result.errors).toEqual([])
     expect(result.headers).toEqual(['topic', 'keywords', 'tone'])
     expect(result.rows).toEqual([
-      { topic: 'AI safety', keywords: 'llm;risk', tone: 'professional' },
+      { topic: 'AI safety', keywords: 'risk', tone: 'professional' },
     ])
+  })
+
+  it('preserves commas inside a quoted keywords cell (matches the template)', () => {
+    // This mirrors the downloadable template and the backend CSV format.
+    const result = parseCSV(
+      'topic,keywords,tone\n"AI in Healthcare","AI,healthcare,medical","professional"'
+    )
+    expect(result.errors).toEqual([])
+    expect(result.rows).toEqual([
+      { topic: 'AI in Healthcare', keywords: 'AI,healthcare,medical', tone: 'professional' },
+    ])
+  })
+
+  it('round-trips quoted keywords into a comma-split list', () => {
+    const result = parseCSV(
+      'topic,keywords,tone\n"AI in Healthcare","AI,healthcare,medical","professional"'
+    )
+    const row = result.rows[0]!
+    const keywords = row.keywords!.split(',').map((k) => k.trim()).filter(Boolean)
+    expect(keywords).toEqual(['AI', 'healthcare', 'medical'])
   })
 
   it('requires a topic column', () => {
@@ -32,6 +52,28 @@ describe('parseCSV', () => {
   it('leaves optional columns undefined when absent', () => {
     const result = parseCSV('topic\nOnly a topic')
     expect(result.rows).toEqual([{ topic: 'Only a topic', keywords: undefined, tone: undefined }])
+  })
+})
+
+describe('parseCSVLine', () => {
+  it('splits a plain line on commas', () => {
+    expect(parseCSVLine('a,b,c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps commas inside quoted fields together', () => {
+    expect(parseCSVLine('"AI in Healthcare","AI,healthcare,medical",professional')).toEqual([
+      'AI in Healthcare',
+      'AI,healthcare,medical',
+      'professional',
+    ])
+  })
+
+  it('unescapes doubled quotes inside a quoted field', () => {
+    expect(parseCSVLine('"She said ""hi""",ok')).toEqual(['She said "hi"', 'ok'])
+  })
+
+  it('trims surrounding whitespace on each field', () => {
+    expect(parseCSVLine(' a , b , c ')).toEqual(['a', 'b', 'c'])
   })
 })
 

--- a/docs/REMEDIATION_PLAN.md
+++ b/docs/REMEDIATION_PLAN.md
@@ -1,93 +1,85 @@
 # Remediation Plan
 
-Living tracker for the codebase remediation effort. Status legend:
-`TODO` · `IN PROGRESS` · `DONE` · `NEEDS-STAGING` (requires a live/staging DB to validate before cutover).
-
----
-
-## Comprehensive Roadmap (v2)
+Single living tracker for the codebase remediation effort. Status legend:
+`TODO` · `IN PROGRESS` · `DONE` · `NEEDS-STAGING` (requires a live/staging DB to
+validate before cutover) · `NEEDS-OWNER` (requires a repo secret or admin action).
 
 Diagnosis: the repo has the apparatus of a production SaaS on top of an
-ambitious, heavily-scaffolded prototype. The work is **finishing and making the
-gauges tell the truth**, not rewriting. Phases are ordered by real-world risk.
-
-### Phase 0 — Truth & safety (stop the bleeding)
-| # | Item | Status |
-|---|------|--------|
-| 0.1 | Land PR #102 (makes `main` backend CI honestly green) | IN PROGRESS |
-| 0.2 | **Critical Clerk auth-bypass CVE** (GHSA-vqx2-fgx2-5wq9) | DONE — bumped to @clerk/nextjs 6.39.5; 25→18 high/critical |
-| 0.3 | Remaining dep CVEs | DONE — next 16.2.7, vitest 4.1.8, vite/undici/flatted overrides; picomatch (dev-only ReDoS) allowlisted. `audit:runtime` gate now passes; 0 blocking high/critical (down from 25) |
-| 0.4 | Schema unification (see P0.1 / `docs/SCHEMA_AUDIT.md`) + CI schema-smoke guard | NEEDS-STAGING |
-| 0.5 | Vercel preview: provide `VERCEL_TOKEN` secret or make check non-required | NEEDS-OWNER |
-
-### Phase 1 — Decide the fate of half-features (kill the ghosts)
-| # | Item | Status |
-|---|------|--------|
-| 1.1 | Knowledge base: finish or remove | DONE (decision: **leave flagged off**) — investigation showed it's integrated RAG (chat), already defaults `ENABLE_KNOWLEDGE_BASE=false`, no CVEs, tests already quarantined. Removal would destroy capability for no safety gain; finishing the pgvector storage layer is a future *product* decision. |
-| 1.2 | Ghost-hunt sweep | DONE — the KB was the only true ghost; other not-in-nav pages (settings/history/admin/privacy/terms) are intentional (footer/user-menu access). |
-
-### Phase 2 — Make the gauges tell the truth
-| # | Item | Status |
-|---|------|--------|
-| 2.1 | Ratchet coverage up toward 70/85 as tests land | ONGOING — frontend floor bumped 9-10% → 10-11% (real: ~12% lines) |
-| 2.2 | Backfill money/security paths (payments, Stripe webhooks, SSO, quotas) | DONE — subscription routes (33%→89%) + webhook HMAC; SSO mappers (SAML/OIDC 19%→~37%); webhook delivery/storage (service 28%→55%, storage 14%→40%) + reconcile guard rails. Backlog closed. |
-| 2.3 | Accessibility sweep: header/footer as siblings of `<main>` repo-wide + landmark checks | DONE — remaining 13 pages restructured (16/16 total incl. #102's 3); `e2e/landmarks.spec.ts` regression guard added |
-
-### Phase 3 — Finish the structural refactors (with nets)
-| # | Item | Status |
-|---|------|--------|
-| 3.1 | `BulkGenerationPageClient` — write bulk-flow component tests, then split the ~1,030-line hook/JSX | IN PROGRESS — 5-test RTL characterization net added; Hero/ActivationHint/WorkflowBanner extracted to `app/bulk/components/PageBanners.tsx` (page 1074→1012). Remaining sections (CSV panel, topics list, job panel) follow the same pinned pattern. |
-| 3.2 | `batch.py` router split (lifecycle vs export) — route tests first | DONE — 15 route-level characterization tests added first (status/results/cancel/list/estimate/template/export incl. ownership scoping + state gating), then the 233-line export endpoint moved to `batch_export.py` (own router, same paths). batch.py 1312→834 overall |
-| 3.3 | Remaining 1,000+ line modules — test-net first | TODO |
-
-### Phase 4 — Keep it honest (durable hygiene)
-| # | Item | Status |
-|---|------|--------|
-| 4.1 | Dependency automation (Dependabot grouping) so the CVE backlog can't silently rebuild | DONE — security updates now grouped into a single batched PR for pip + npm |
-| 4.2 | Docs-vs-reality reconciliation (`DATABASE.md`, drop unverified "100/100" claims) | DONE — README claims replaced with CI-enforced quality bar (dropped unverified Lighthouse/React-Doctor scores + stale home.html note); `DATABASE.md` carries an accuracy warning pointing to `SCHEMA_AUDIT.md` until the P0.1 consolidation lands |
-| 4.3 | Re-enable branch protection once `main` is genuinely green | NEEDS-OWNER |
+ambitious, heavily-scaffolded prototype. The remaining work is **finishing the
+last mile so a brand-new user can run the product end to end**, and keeping the
+gauges honest — not rewriting.
 
 ---
-## Original tracker (P0–P3) — completed-work record
 
-## P0 — Correctness / single source of truth
+## Active focus — End-to-end usability
 
-| ID | Item | Status |
-|----|------|--------|
-| P0.1 | Unify schema management onto one migration system | IN PROGRESS — audit complete (`docs/SCHEMA_AUDIT.md`), consolidation NEEDS-STAGING |
-| P0.2 | Make the backend full suite blocking (or explicitly quarantine) | DONE |
+These are the gaps that block a fresh install / new user. Ordered by how hard
+they break the first-run experience.
 
-## P1 — Test integrity
+| # | Item | Status |
+|---|------|--------|
+| E1 | Fresh-install schema completion — `db:migrate` must produce a working DB (see `docs/SCHEMA_AUDIT.md`) | NEEDS-STAGING |
+| E2 | CSV bulk import round-trip (quoted-comma parsing + consistent comma delimiter across template/parser/editor) | DONE |
+| E3 | Gate the `/knowledge` nav link behind `NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE` so the UI never links to a flagged-off backend | DONE |
+| E4 | `/auth` no longer dead-ends when Clerk is unconfigured — routes new users straight into the workspace | DONE |
+| E5 | Stripe pre-flight: surface missing price IDs clearly before checkout instead of warn-only | TODO |
 
-| ID | Item | Status |
-|----|------|--------|
-| P1.1 | Frontend coverage `all: true` + ratchet to real baseline | DONE — floor ratcheted 9→10% after surfacing existing `lib/api.ts` coverage (was excluded; actually ~74%) + new csv tests |
-| P1.2 | Backfill tests for highest-risk untested surfaces | IN PROGRESS — 19 rate-limiter tests + 6 batch-provider tests + 7 frontend csv tests (all 3 surfaces had 0); fixed a pre-existing stripe-mock test-isolation bug; more surfaces TODO |
-| P1.3 | Expand backend coverage gate beyond 5 routes | DONE — added ratchet floor (50%) for organizations/sso/export/research; gate now covers 9 modules |
+---
 
-## P2 — Maintainability (god-file refactors)
+## Phase 0 — Truth & safety (stop the bleeding)
 
-| ID | File | Status |
-|----|------|--------|
-| P2.1 | `marketing_templates.py` (1944) → fields/categories/per-category modules | DONE — assembler is 42 lines; 7 category modules (≤369 lines); registry SHA verified identical |
-| P2.2 | `rate_limit.py` (1288) → backends/models/shared base | DONE — backends → `rate_limit_backends.py`; `RateLimiter`/`GenerationRateLimiter` deduped onto shared `_BaseRateLimiter` (1288→880 lines). 19 rate-limiter tests; full suite green |
-| P2.3 | `batch.py` (1312) → providers/item_processor/csv/lifecycle+export routers | PARTIAL — extracted `batch_providers.py` (6 tests), `batch_csv.py` (7 tests), and `batch_item_processor.py`; batch.py 1312→1076 lines. Export router split DONE (see Phase 3.2); batch.py 1312→834 |
-| P2.4 | `BulkGenerationPageClient.tsx` (1164) → constants/csv/hooks/components | PARTIAL — extracted `constants.ts` + pure `csv.ts` (1164→1074 lines) + 7 vitest tests for parseCSV/createDraftItem. Remaining: split the page-view hook and the 600-line render into components |
-| P2.5 | `HomePageClient.tsx` (858) → data/animations/sections | DONE — extracted `_home/data.ts` + `_home/animations.ts` (858→622 lines) |
+| # | Item | Status |
+|---|------|--------|
+| 0.1 | Backend CI honestly green on `main` (PR #102) | DONE |
+| 0.2 | **Critical Clerk auth-bypass CVE** (GHSA-vqx2-fgx2-5wq9) | DONE — bumped to @clerk/nextjs 6.39.5 |
+| 0.3 | Remaining dep CVEs | DONE — `audit:runtime` gate passes; 0 blocking high/critical (down from 25) |
+| 0.4 | Schema unification + CI schema-smoke guard (= E1) | NEEDS-STAGING |
+| 0.5 | Vercel preview: provide `VERCEL_TOKEN` secret or make check non-required | NEEDS-OWNER |
+| 0.6 | Re-enable branch protection once `main` is genuinely green | NEEDS-OWNER |
 
-## P3 — Onboarding & hygiene
+## Phase 1 — Decide the fate of half-features
 
-| ID | Item | Status |
-|----|------|--------|
-| P3.1 | Tier `.env.example` (required vs optional) | DONE — quick-start block added |
-| P3.2 | Audit the 7 `eslint-disable`s | DONE — all intentional; justifications added |
-| P3.3 | Document Next 16 / React 18 pin + React 19 follow-up | DONE |
-| P3.4 | Consolidate rollback docs (after P0.1) | TODO (blocked on P0.1 cutover) |
+| # | Item | Status |
+|---|------|--------|
+| 1.1 | Knowledge base: finish or remove | DONE (decision: **leave flagged off**) — it's integrated RAG (chat), defaults `ENABLE_KNOWLEDGE_BASE=false`, no CVEs. Finishing the pgvector storage layer is a future *product* decision. UI link now gated (E3). |
+| 1.2 | Ghost-hunt sweep | DONE — KB was the only true ghost; other not-in-nav pages (settings/history/admin/privacy/terms) are intentional (footer/user-menu access). |
 
-## Sequencing
+## Phase 2 — Make the gauges tell the truth
 
-1. **Foundations (this wave):** P0.2, P3.3, schema audit for P0.1.
-2. **Test honesty:** P1.1 (coverage `all: true`), then P1.2/P1.3 backfills.
-3. **Refactors (test-covered first):** P2.5 → P2.1 → P2.4 → P2.3 → P2.2.
-4. **Hygiene in parallel:** P3.1, P3.2, P3.4.
-5. **P0.1 cutover:** only after validating the consolidated schema against a staging DB.
+| # | Item | Status |
+|---|------|--------|
+| 2.1 | Ratchet frontend coverage up toward 70/85 as tests land | ONGOING — floor at 10/11/11/11 (branches/functions/lines/statements); never lowered to pass a build. |
+| 2.2 | Backfill money/security paths (payments, Stripe webhooks, SSO, quotas) | DONE — subscription routes 33%→89% + webhook HMAC; SSO mappers 19%→~37%; webhook delivery/storage service 28%→55%, storage 14%→40%. |
+| 2.3 | Accessibility: header/footer as siblings of `<main>` repo-wide + landmark checks | DONE — 16/16 pages restructured; `e2e/landmarks.spec.ts` regression guard. |
+| 2.4 | Backend coverage gate beyond 5 routes | DONE — ratchet floor (50%) for organizations/sso/export/research; gate covers 9 modules. |
+
+## Phase 3 — Finish the structural refactors (with test nets)
+
+| # | Item | Status |
+|---|------|--------|
+| 3.1 | `BulkGenerationPageClient.tsx` (1164) — characterization tests, then split hook/JSX | IN PROGRESS — 5-test RTL net + 13-test csv unit suite; Hero/ActivationHint/WorkflowBanner extracted to `app/bulk/components/PageBanners.tsx`. Remaining: CSV panel, topics list, job panel. |
+| 3.2 | `batch.py` (1312) router split (lifecycle vs export) | DONE — 15 route tests first, then export endpoint → `batch_export.py`; batch.py 1312→834. |
+| 3.3 | `marketing_templates.py` (1944) → fields/categories modules | DONE — assembler 42 lines; 7 category modules; registry SHA verified identical. |
+| 3.4 | `rate_limit.py` (1288) → backends/models/shared base | DONE — deduped onto `_BaseRateLimiter` (1288→880); 19 tests. |
+| 3.5 | `HomePageClient.tsx` (858) → data/animations/sections | DONE — extracted `_home/data.ts` + `_home/animations.ts` (858→622). |
+| 3.6 | Remaining 1,000+ line modules — test-net first | TODO |
+
+## Phase 4 — Keep it honest (durable hygiene)
+
+| # | Item | Status |
+|---|------|--------|
+| 4.1 | Dependency automation (Dependabot grouping) | DONE — security updates grouped into one batched PR for pip + npm. |
+| 4.2 | Docs-vs-reality reconciliation (drop unverified "100/100" claims) | DONE — README claims replaced with CI-enforced quality bar; `DATABASE.md` carries an accuracy warning pointing to `SCHEMA_AUDIT.md` until E1 lands. |
+| 4.3 | `.env.example` tiered (required vs optional) + Next 16/React 18 pin documented | DONE. |
+| 4.4 | Audit the 7 `eslint-disable`s | DONE — all intentional; justifications added. |
+| 4.5 | Consolidate rollback docs | TODO (blocked on E1 cutover). |
+
+---
+
+## Completed-work record (refactor sizing, for reference)
+
+- `marketing_templates.py` 1944 → 42-line assembler + 7 modules (≤369 lines each).
+- `rate_limit.py` 1288 → 880 (shared base; 19 tests).
+- `batch.py` 1312 → 834 (export router split; 15 route tests).
+- `BulkGenerationPageClient.tsx` 1164 → ~1012 (constants + pure `csv.ts` + banners; 18 tests).
+- `HomePageClient.tsx` 858 → 622 (data + animations extracted).


### PR DESCRIPTION
## What & why

User-facing quick fixes from the end-to-end usability review (findings #2, #3, #4, #9). These are the small breakages a brand-new user hits first.

### 1. CSV bulk-import round-trip (finding #2) — the big one
The bulk CSV import was broken end-to-end by a delimiter mismatch:
- The **backend** template and parser use **comma-separated keywords inside quoted cells** (`"AI,healthcare,medical"`).
- The **frontend template download** and the **parser consumer** used **semicolons** (`;`).
- The **inline editor** already used commas.
- And `parseCSV` did a naive `line.split(',')`, which **mangled any quoted comma cell** — including the official template's own example row.

Fixes:
- New quote-aware `parseCSVLine()` honors double-quoted cells (and `""` escapes), so commas inside a quoted keywords list survive.
- Standardized the keyword delimiter on **comma** across template download, parser consumer, and inline editor — now consistent with the backend (the source of truth).
- Added `parseCSVLine` tests + a quoted-comma round-trip test (the old test used `llm;risk`, which masked the bug).

### 2. Gate the `/knowledge` nav link (finding #3)
The header linked to `/knowledge`, but the backend Knowledge Base ships **flagged off** (`ENABLE_KNOWLEDGE_BASE=false`). New users clicked into a rejected route. Now gated behind `NEXT_PUBLIC_ENABLE_KNOWLEDGE_BASE` (default off, mirrors the backend), documented in `.env.example`.

### 3. `/auth` dead-end (finding #4)
When Clerk is unconfigured (the documented default dev mode where all routes are public), `/auth` showed a `Set NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY...` message a visitor can't act on. Now it explains no sign-in is required and links straight into the workspace (`/generate`).

### 4. Tracker consolidation (finding #9)
`docs/REMEDIATION_PLAN.md` had two overlapping trackers with contradictory statuses (e.g. PR #102 still "IN PROGRESS", one refactor both "IN PROGRESS" and "PARTIAL"). Collapsed into a single tracker with an "Active focus — End-to-end usability" section.

## Verification
- `bun run lint` ✅
- `bunx tsc --noEmit` ✅
- `bunx vitest run tests/app/bulk` ✅ (18 tests)

CSV change is the only behavior change to existing data flow; covered by new round-trip tests.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_