### PR TITLE
fix(docker): apply base-image security upgrades (openssl CVE-2026-45447)

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -42,8 +42,9 @@ RUN groupadd --system --gid 1001 blogai && \
 
 WORKDIR /app
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Apply base-image security updates, then install curl for healthcheck
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -87,8 +87,11 @@ RUN groupadd --system --gid 1001 blogai && \
 
 WORKDIR /app
 
-# Install runtime dependencies only
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install runtime dependencies only. Apply available base-image security
+# updates first (e.g. openssl/libssl3 CVE fixes) so the published image picks
+# up patched system packages rather than shipping the base image's snapshot.
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     curl \
     nodejs \
     tini \


### PR DESCRIPTION
## What & why

The **Container Security Scan** (Trivy on `Dockerfile.prod`) started failing on every PR — and on `main` — with a freshly-disclosed base-image CVE:

```
blog-ai:security-scan (debian 13.5)
Total: 3 (HIGH: 3, CRITICAL: 0)
libssl3t64 / openssl / openssl-provider-legacy
CVE-2026-45447  HIGH  fixed  3.5.6-1~deb13u1 → 3.5.6-1~deb13u2
```

This is in the OS `openssl`/`libssl3` packages of the `python:3.12-slim` (debian 13) base, not in our code or dependencies — so it affects `main` directly and blocks the security gate on all open PRs.

## Fix

Run `apt-get upgrade -y` in the runtime stage of `Dockerfile.prod` (and the equivalent stage of `Dockerfile.backend`, used by the deploy workflow) so the published images pull the patched system packages instead of shipping the base image's frozen snapshot. The fix is available in the debian 13 repos (`3.5.6-1~deb13u2`), so the upgrade resolves it without pinning.

This is the durable hygiene approach: future base-image CVEs that already have fixes get picked up at build time rather than requiring a per-CVE `.trivyignore` entry.

## Verification
- Docker daemon isn't available in my sandbox, so the image build + Trivy scan are validated by this PR's own **Container Security Scan** check.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_