### PR TITLE
fix(db): close fresh-install money-path schema gap + add schema-smoke CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,49 @@ jobs:
           set -euo pipefail
           gitleaks git --no-banner --redact --exit-code 1 --log-opts="${GITLEAKS_LOG_OPTS}" .
 
+  schema-smoke:
+    name: Schema Smoke (fresh-install migration)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: blogai
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Apply the db/migrations set the way the runner (scripts/migrate_db.mjs)
+      # does — in sorted order — using psql. We use psql rather than the runner
+      # itself because the runner's @neondatabase/serverless driver talks to Neon
+      # over WebSocket and can't reach a plain Postgres service. This still
+      # validates the SQL and ordering, which is where the schema risk lives.
+      - name: Apply db/migrations to a fresh database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          for f in db/migrations/*.sql; do
+            echo "Applying ${f}"
+            psql -h localhost -U postgres -d blogai -v ON_ERROR_STOP=1 -q -f "${f}"
+          done
+
+      # Fail if the migrated schema is missing any table/column the backend code
+      # references. Prevents the schema from silently re-fragmenting.
+      - name: Assert code-referenced tables exist
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          psql -h localhost -U postgres -d blogai -v ON_ERROR_STOP=1 -f scripts/schema_smoke.sql
+
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/apps/api/src/knowledge/quota.py
+++ b/apps/api/src/knowledge/quota.py
@@ -41,7 +41,7 @@ async def _get_user_tier(user_id: str) -> str:
             async with pool.acquire() as conn:
                 row = await conn.fetchrow(
                     """
-                    SELECT tier FROM user_subscriptions
+                    SELECT tier FROM stripe_subscriptions
                     WHERE user_id = $1 AND status = 'active'
                     ORDER BY created_at DESC LIMIT 1
                     """,

--- a/db/migrations/006_stripe_webhook_events.sql
+++ b/db/migrations/006_stripe_webhook_events.sql
@@ -1,0 +1,58 @@
+-- Migration 006: Stripe webhook event log + subscription payment status
+--
+-- Closes a fresh-install gap: the Stripe subscription sync service
+-- (src/payments/subscription_sync.py) requires both of these to exist, but they
+-- were previously only defined in supabase/migrations/019 — which the migration
+-- runner (scripts/migrate_db.mjs, db/migrations only) never applies. On a fresh
+-- database the webhook handler crashed on the idempotency check and the
+-- subscription upsert (missing payment_status column).
+--
+-- This is the portable, Neon-friendly form: no RLS policies, no Supabase
+-- `service_role`/`authenticated` grants (the app authorizes in Python and
+-- connects with a single role), and idempotent so it is safe to run against an
+-- already-populated database.
+
+-- Idempotency + audit log of processed Stripe webhook events.
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id text NOT NULL UNIQUE,
+  event_type text NOT NULL,
+  user_id text,
+  customer_id text,
+  subscription_id text,
+  processed_at timestamptz NOT NULL DEFAULT NOW(),
+  sync_result jsonb,
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+-- Fast duplicate lookups by Stripe event id (primary use case).
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_event_id
+  ON stripe_webhook_events(event_id);
+
+-- Auditing by user.
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_user_id
+  ON stripe_webhook_events(user_id)
+  WHERE user_id IS NOT NULL;
+
+-- Event-type filtering / recent-first scans.
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_type_time
+  ON stripe_webhook_events(event_type, processed_at DESC);
+
+-- Grace-period / payment-health tracking written by the subscription sync upsert.
+ALTER TABLE stripe_subscriptions
+  ADD COLUMN IF NOT EXISTS payment_status text DEFAULT 'current'
+    CHECK (payment_status IN ('current', 'grace_period', 'payment_failed'));
+
+-- Retention helper for the webhook event log (keeps `retention_days`, default 90).
+CREATE OR REPLACE FUNCTION cleanup_old_webhook_events(retention_days integer DEFAULT 90)
+RETURNS integer AS $$
+DECLARE
+  v_deleted integer;
+BEGIN
+  DELETE FROM stripe_webhook_events
+  WHERE processed_at < NOW() - (retention_days || ' days')::interval;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$ LANGUAGE plpgsql;

--- a/docs/SCHEMA_AUDIT.md
+++ b/docs/SCHEMA_AUDIT.md
@@ -1,8 +1,20 @@
 # Schema Source-of-Truth Audit (P0.1)
 
-> **Status:** Analysis complete. The migration *runner cutover* is gated on validating
-> the consolidated schema against a live/staging database (see "Cutover plan" below).
-> Do **not** repoint the runner in production until that validation passes.
+> **Status:** Analysis complete. **Money-path gap closed** — the Stripe webhook
+> idempotency log (`stripe_webhook_events`) and the `stripe_subscriptions.payment_status`
+> column, previously only in the never-applied `supabase/migrations/019`, are now in the
+> runner-applied set (`db/migrations/006_stripe_webhook_events.sql`). A CI **schema-smoke**
+> gate (`scripts/schema_smoke.sql`, run by the `schema-smoke` job) now boots a fresh
+> Postgres, applies `db/migrations/`, and fails if any code-referenced table/column is
+> missing — so a fresh install is verified deterministically and the schema can't silently
+> re-fragment. The full multi-source *runner cutover* (folding the supabase-only analytics/
+> social/seo/plagiarism domains and the pgvector knowledge-base tables) remains gated on
+> validating against a live/staging database — see "Cutover plan" below. Do **not** repoint
+> the runner onto the supabase set in production until that validation passes.
+>
+> **Fresh-install correctness fix:** `src/knowledge/quota.py` queried a non-existent
+> `user_subscriptions` table (silently falling back to the `free` tier); it now reads the
+> real, populated `stripe_subscriptions` table.
 
 ## Problem
 

--- a/scripts/schema_smoke.sql
+++ b/scripts/schema_smoke.sql
@@ -1,0 +1,72 @@
+-- Schema smoke guard (pure SQL, no driver dependency).
+--
+-- Asserts that the migration runner (scripts/migrate_db.mjs, which applies only
+-- db/migrations/) produces every table the backend code actually queries. This
+-- makes "fresh install is missing tables" a CI-enforced failure and keeps the
+-- schema from silently re-fragmenting. See docs/SCHEMA_AUDIT.md.
+--
+-- Usage (after applying db/migrations against the target database):
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/schema_smoke.sql
+--
+-- Intentionally NOT required here:
+--   * kb_documents / kb_embeddings / kb_usage_stats — gated behind
+--     ENABLE_KNOWLEDGE_BASE and need the pgvector extension, so they live in
+--     apps/api/migrations/002_knowledge_base.sql, outside the default runner.
+--   * webhook_* (outbound webhooks) — the webhook store is Redis/memory backed;
+--     no code references those tables.
+
+DO $$
+DECLARE
+  required_tables text[] := ARRAY[
+    'app_sso_auth_sessions',
+    'app_sso_configurations',
+    'app_sso_user_sessions',
+    'app_workflow_executions',
+    'app_workflows',
+    'audit_logs',
+    'blog_posts',
+    'brand_profiles',
+    'generated_content',
+    'organization_invites',
+    'organization_members',
+    'organizations',
+    'payment_failures',
+    'payments',
+    'research_queries',
+    'research_sources',
+    'stripe_customers',
+    'stripe_subscriptions',
+    'stripe_webhook_events',
+    'templates',
+    'usage_records',
+    'user_quotas',
+    'voice_fingerprints',
+    'voice_samples'
+  ];
+  t text;
+  missing text[] := ARRAY[]::text[];
+BEGIN
+  -- Required tables.
+  FOREACH t IN ARRAY required_tables LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      missing := array_append(missing, 'table ' || t);
+    END IF;
+  END LOOP;
+
+  -- Columns added by later migrations whose absence has broken the money path.
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stripe_subscriptions'
+      AND column_name = 'payment_status'
+  ) THEN
+    missing := array_append(missing, 'column stripe_subscriptions.payment_status');
+  END IF;
+
+  IF array_length(missing, 1) > 0 THEN
+    RAISE EXCEPTION E'Schema smoke FAILED — fresh-install migration is incomplete.\nMissing: %\nAdd the missing definitions to db/migrations/ (the only directory the runner applies). See docs/SCHEMA_AUDIT.md.',
+      array_to_string(missing, ', ');
+  END IF;
+
+  RAISE NOTICE 'Schema smoke OK — all % required tables present.', array_length(required_tables, 1);
+END $$;


### PR DESCRIPTION
## The bug (finding #1 — the #1 fresh-install blocker)

A brand-new database provisioned with `bun run db:migrate` was **silently incomplete on the money path**. The migration runner (`scripts/migrate_db.mjs`) applies **only** `db/migrations/`, but two things the Stripe subscription sync *requires* lived only in `supabase/migrations/019` — which nothing applies:

- `stripe_webhook_events` (webhook idempotency log) — `subscription_sync.py:68` does `SELECT 1 FROM stripe_webhook_events ...` and `:96` `INSERT INTO stripe_webhook_events ...`
- `stripe_subscriptions.payment_status` column — written by the subscription upsert (`subscription_sync.py:804+`) and `_update_subscription_payment_status`

So on a fresh install, **Stripe webhook processing crashed** — a paying user's subscription would never activate. This is the kind of break that only shows up in production.

I scoped this surgically using an evidence-based table inventory (every table the `apps/api` code references vs. what each migration source creates):
- **Excluded** `webhook_*` tables — the webhook store is Redis/memory-backed; **zero** code references them (dead).
- **Excluded** `kb_*` (knowledge base) — gated behind `ENABLE_KNOWLEDGE_BASE` and needs the `pgvector` extension, which would *break* `db:migrate` on environments without it. Stays in `apps/api/migrations/` outside the default runner.

## Changes

1. **`db/migrations/006_stripe_webhook_events.sql`** — adds `stripe_webhook_events` (+ indexes), the `payment_status` column, and the cleanup helper. Portable/idempotent: no RLS, no Supabase `service_role` grants (the app authorizes in Python and connects with a single role), safe to run against an already-populated DB.
2. **`scripts/schema_smoke.sql` + a `schema-smoke` CI job** — boots a fresh Postgres service, applies `db/migrations/` in order, and **fails if any code-referenced table/column is missing**. Turns "fresh install is broken" into a CI-enforced guarantee and stops the schema from silently re-fragmenting.
3. **`fix(api)` `quota.py`** — it queried a non-existent `user_subscriptions` table (silently falling back to the `free` tier); now reads the real, populated `stripe_subscriptions`.
4. **`docs/SCHEMA_AUDIT.md`** — records the money-path cutover + the smoke gate; the broader multi-source consolidation stays `NEEDS-STAGING`.

## Verification (real Postgres 16, locally)
- All 6 migrations apply cleanly **and are idempotent** (re-run is a no-op).
- `schema_smoke.sql` **passes** on the complete schema (24 tables) and **fails** on the pre-006 schema, naming the exact gap (`table stripe_webhook_events, column stripe_subscriptions.payment_status`).
- The CI `schema-smoke` job was simulated end-to-end (fresh DB → psql apply → smoke).
- Backend tests: `test_knowledge_quota.py` + `test_subscription_sync.py` pass (56 tests).

Note: the CI job applies migrations via `psql` rather than the runner itself, because the runner's `@neondatabase/serverless` driver talks to Neon over WebSocket and can't reach a plain Postgres service — but it validates the same SQL and ordering, which is where the schema risk lives.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_