### PR TITLE
fix(payments): clear error when no Stripe plans are configured (checkout pre-flight)

### DIFF
--- a/apps/api/app/routes/payments.py
+++ b/apps/api/app/routes/payments.py
@@ -80,6 +80,23 @@ async def create_checkout_session(
 
     # SECURITY: only allow checkout for configured plan price IDs.
     if not stripe_service.is_configured_price_id(request.price_id):
+        # Pre-flight: disambiguate an operator misconfiguration (Stripe key set
+        # but no STRIPE_PRICE_ID_* values) from a client sending an unknown
+        # price_id. Without this, a server with no plans returns "invalid
+        # price_id" for every plan — a confusing dead end at checkout.
+        if not stripe_service.has_configured_plans:
+            logger.error(
+                "Checkout requested but no Stripe plan price IDs are configured "
+                "(set STRIPE_PRICE_ID_STARTER / _PRO / _BUSINESS)."
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "error": "Subscription plans are not available right now. "
+                    "Please try again later.",
+                    "success": False,
+                },
+            )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"error": "Invalid price_id", "success": False},

--- a/apps/api/src/payments/stripe_service.py
+++ b/apps/api/src/payments/stripe_service.py
@@ -79,6 +79,21 @@ class StripeService:
         """Check if Stripe is properly configured."""
         return bool(self._api_key)
 
+    @property
+    def has_configured_plans(self) -> bool:
+        """Return True when at least one plan price ID is configured.
+
+        Distinguishes an operator misconfiguration (Stripe key set but no
+        STRIPE_PRICE_ID_* values) from a client sending an unknown price_id, so
+        checkout can surface a clear, actionable error instead of a confusing
+        'invalid price_id' for every plan.
+        """
+        for ids in self._price_ids.values():
+            for pid in ids.values():
+                if pid:
+                    return True
+        return False
+
     def _ensure_configured(self) -> None:
         """Raise an error if Stripe is not configured."""
         if not self.is_configured:

--- a/apps/api/tests/test_routes_payments.py
+++ b/apps/api/tests/test_routes_payments.py
@@ -60,12 +60,24 @@ class TestPaymentCheckoutRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("not configured", detail_text(response))
 
+    @patch("app.routes.payments.stripe_service._price_ids", {"pro": {"month": "price_pro_month"}})
     @patch("app.routes.payments.stripe_service.is_configured_price_id", return_value=False)
     @patch("app.routes.payments.stripe_service._api_key", "sk_test_123")
     def test_checkout_rejects_unconfigured_price_id(self, _mock_price):
+        # Server has plans configured, but the client sent an unknown price_id.
         response = self.client.post("/api/payments/create-checkout-session", json=CHECKOUT_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertIn("invalid price_id", detail_text(response))
+
+    @patch("app.routes.payments.stripe_service._price_ids", {})
+    @patch("app.routes.payments.stripe_service.is_configured_price_id", return_value=False)
+    @patch("app.routes.payments.stripe_service._api_key", "sk_test_123")
+    def test_checkout_returns_503_when_no_plans_configured(self, _mock_price):
+        # Stripe key is set but no STRIPE_PRICE_ID_* values — operator
+        # misconfiguration should surface distinctly, not as "invalid price_id".
+        response = self.client.post("/api/payments/create-checkout-session", json=CHECKOUT_PAYLOAD)
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("not available", detail_text(response))
 
     @patch("app.routes.payments.stripe_service.get_tier_for_price_id", return_value=SubscriptionTier.FREE)
     @patch("app.routes.payments.stripe_service.is_configured_price_id", return_value=True)


### PR DESCRIPTION
## What & why (finding #5 — payment-path UX)

If the server has a Stripe secret key set but **no plan price IDs** (`STRIPE_PRICE_ID_STARTER` / `_PRO` / `_BUSINESS`), the checkout endpoint returned `400 "Invalid price_id"` for *every* plan — an operator misconfiguration disguised as a client error, leaving the user at a dead end and the operator with no signal. The config validator only logged a warn-level note at startup.

## Change

- `stripe_service.has_configured_plans` — true when at least one plan price ID exists.
- Checkout pre-flight: when the requested `price_id` isn't recognized, **disambiguate**:
  - server has no plans configured → `503 "Subscription plans are not available right now"` + an operator-facing `logger.error` naming the env vars to set.
  - server has plans, client sent an unknown id → unchanged `400 "Invalid price_id"`.

The check is nested inside the existing `is_configured_price_id` failure path, so the success path and all other checkout behavior are untouched.

## Verification
- `tests/test_routes_payments.py` — 25 pass, including a new `test_checkout_returns_503_when_no_plans_configured` and the existing invalid-price_id test (updated to simulate a configured server).
- Aggregate route coverage gate (blog/book/webhooks/payments/usage) passes at 85.29% (≥85%).

## Remaining code-review findings (lower priority, follow-up)
Not in this PR to keep it focused and conflict-free with the other open PRs: #6 coverage-ratchet escalation policy, #7 CI runs pytest 4×, #8 `list_batch_jobs` double scan, #10 hero/banner dedup. I'll land these as a cleanup PR once #120/#122 merge.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_