### PR TITLE
perf(batch) + chore: single-scan job listing, ratchet coverage floor

### DIFF
--- a/apps/api/app/routes/batch.py
+++ b/apps/api/app/routes/batch.py
@@ -704,19 +704,15 @@ async def list_batch_jobs(
     # Use organization_id for scoping if available, fallback to user_id (multi-tenant isolation)
     scope_id = auth_ctx.organization_id or auth_ctx.user_id
     status_str = status_filter.value if status_filter else None
-    jobs = await _job_store.list_jobs(
-        user_id=scope_id,
-        status=status_str,
-        limit=limit,
-        offset=offset,
-    )
 
-    # Note: The job_store.list_jobs already returns paginated results
-    # We need to get total count separately for proper pagination info
+    # The store fetches the full owned set internally on every call, so fetch
+    # once and paginate in-process instead of scanning twice (one page query +
+    # one count query). The cap matches the previous count query's bound.
     all_jobs = await _job_store.list_jobs(
         user_id=scope_id, status=status_str, limit=1000, offset=0
     )
     total = len(all_jobs)
+    jobs = all_jobs[offset : offset + limit]
 
     return {
         "jobs": [j.model_dump() for j in jobs],

--- a/apps/api/tests/test_routes_batch.py
+++ b/apps/api/tests/test_routes_batch.py
@@ -194,7 +194,9 @@ class TestListJobs(BatchRouteTestCase):
     def test_list_returns_pagination_shape(self):
         jobs = [make_job(job_id=f"job-{i}") for i in range(3)]
         store = MagicMock()
-        store.list_jobs = AsyncMock(side_effect=[jobs[:2], jobs])
+        # A single fetch returns the full owned set; the route paginates it
+        # in-process (no second count scan).
+        store.list_jobs = AsyncMock(return_value=jobs)
         with patch("app.routes.batch._job_store", store):
             resp = self.client.get("/batch/jobs?limit=2&offset=0")
         assert resp.status_code == 200
@@ -202,6 +204,8 @@ class TestListJobs(BatchRouteTestCase):
         assert len(data["jobs"]) == 2
         assert data["total"] == 3
         assert data["has_more"] is True
+        # Exactly one store scan, not two.
+        assert store.list_jobs.await_count == 1
 
 
 if __name__ == "__main__":

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -46,16 +46,22 @@ export default defineConfig({
         '../../supabase/**',
       ],
       // Ratchet policy: these reflect the REAL baseline measured with all:true
-      // (~10% — the previous all:false gate only saw the ~600 statements tests
+      // (the previous all:false gate only saw the ~600 statements tests
       // imported, hiding ~90% of the app) and only ever move UP. Target:
       // branches 70 / functions+lines+statements 85 as tests are backfilled
       // (see docs/REMEDIATION_PLAN.md P1.1/P1.2). Do NOT lower these to make a
       // red build green — add tests instead.
+      //
+      // Escalation: when measured coverage clears the next whole percent with a
+      // safe margin, raise the corresponding floor here so the ratchet actually
+      // tightens. Last raised to match measured lines 12.5% / statements 12.3% /
+      // functions 11.8% / branches 10.4% (bulk CSV tests). Branches/functions
+      // sit just under the next integer, so they hold until the next backfill.
       thresholds: {
         branches: 10,
         functions: 11,
-        lines: 11,
-        statements: 11,
+        lines: 12,
+        statements: 12,
       },
     },
   },


### PR DESCRIPTION
## What & why (code-review findings #8 and #6)

### #8 — `list_batch_jobs` double scan
The endpoint called the store twice: once for the page, once more with `limit=1000` purely to compute the total. But `job_storage.list_user_jobs` already fetches the **entire** owned job set on every call (it `ZREVRANGE 0 -1`s the user's set, loads each job, then paginates in Python) — so this was two full scans plus a redundant deserialize pass. Now it fetches once and slices/counts in-process. Behavior-preserving (same `total`, page, `has_more`); the characterization test is updated to assert a single scan.

### #6 — coverage ratchet escalation
The vitest floor had stalled at `11` while real coverage had climbed. Raised `lines`/`statements` `11 → 12` to match measured coverage (lines 12.5%, statements 12.3%) and documented the explicit escalation rule so the ratchet keeps tightening. Branches (10.4%) and functions (11.8%) sit just below the next integer, so they hold until the next backfill.

## Verification
- `pytest tests/test_routes_batch.py` — all pass (incl. updated pagination + single-scan assertion).
- `bunx vitest run --coverage` — exits 0 with the bumped floors (lines 12.52 ≥ 12, statements 12.25 ≥ 12).

## Deliberately not included
- **#7** (CI runs pytest in several passes): the passes are distinct coverage gates (85% critical routes, 50% ratchet, full regression). Collapsing them risks losing those gates for marginal CI-time savings — not worth the risk.
- **#10** (hero/banner dedup): already addressed — the shared `BulkHero`/`ActivationHint`/`WorkflowBanner` were extracted to `app/bulk/components/PageBanners.tsx` in an earlier PR.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_