### PR TITLE
feat(versions): port content versioning from Supabase to Neon/asyncpg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,62 @@ jobs:
           set -euo pipefail
           psql -h localhost -U postgres -d blogai -v ON_ERROR_STOP=1 -f scripts/schema_smoke.sql
 
+  backend-db-tests:
+    name: Backend DB Tests (Postgres)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: blogai
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: apps/api/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest pytest-asyncio
+
+      # Apply db/migrations so the asyncpg-backed services have their tables.
+      - name: Apply db/migrations
+        working-directory: .
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          for f in db/migrations/*.sql; do
+            psql -h localhost -U postgres -d blogai -v ON_ERROR_STOP=1 -q -f "${f}"
+          done
+
+      # Run the DB-backed integration tests against the real Postgres. These
+      # skip in the no-DB backend-tests job; here they exercise the asyncpg
+      # service implementations end to end.
+      - name: Run DB-backed tests
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/blogai
+          DEV_MODE: "true"
+          OPENAI_API_KEY: "test"
+        run: |
+          pytest tests/test_version_service.py -q
+
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/apps/api/src/content/version_service.py
+++ b/apps/api/src/content/version_service.py
@@ -19,11 +19,11 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 from src.types.version import (
+    DEFAULT_AUTO_VERSION_CONFIG,
     AutoVersionConfig,
     ChangeType,
     ContentVersion,
     ContentVersionSummary,
-    DEFAULT_AUTO_VERSION_CONFIG,
     VersionComparison,
     VersionStatistics,
 )
@@ -251,8 +251,12 @@ def generate_unified_diff(
     )
 
     diff_lines = list(diff)
-    additions = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
-    deletions = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    additions = sum(
+        1 for line in diff_lines if line.startswith("+") and not line.startswith("+++")
+    )
+    deletions = sum(
+        1 for line in diff_lines if line.startswith("-") and not line.startswith("---")
+    )
 
     return "".join(diff_lines), additions, deletions
 
@@ -520,7 +524,9 @@ class InMemoryVersionService(BaseVersionService):
         word_diff = abs(new_word_count - latest.word_count)
         char_diff = abs(new_char_count - latest.character_count)
 
-        return word_diff >= config.min_word_change or char_diff >= config.min_char_change
+        return (
+            word_diff >= config.min_word_change or char_diff >= config.min_char_change
+        )
 
     async def is_content_in_organization(
         self,
@@ -568,6 +574,394 @@ class InMemoryVersionService(BaseVersionService):
         return True
 
 
+class NeonVersionService(BaseVersionService):
+    """Postgres/Neon-backed version service using the shared asyncpg pool.
+
+    Persists to the content_versions and content_version_organizations tables
+    (db/migrations/007). Mirrors InMemoryVersionService semantics but durably,
+    and is the production path for the Neon-only deployment.
+    """
+
+    def __init__(self) -> None:
+        logger.info("Initialized Neon (asyncpg) version service")
+
+    @staticmethod
+    def _row_to_version(row) -> ContentVersion:
+        return ContentVersion(
+            id=str(row["id"]),
+            content_id=row["content_id"],
+            version_number=row["version_number"],
+            content=row["content"],
+            content_hash=row["content_hash"],
+            diff_from_previous=row["diff_from_previous"],
+            change_type=ChangeType(row["change_type"]),
+            change_summary=row["change_summary"],
+            word_count=row["word_count"],
+            character_count=row["character_count"],
+            created_by=row["created_by"],
+            created_at=row["created_at"],
+            is_current=row["is_current"],
+        )
+
+    async def _pool(self):
+        from ..db import get_pool
+
+        pool = await get_pool()
+        if pool is None:
+            raise RuntimeError(
+                "Neon version service selected but no database pool is available "
+                "(DATABASE_URL not configured)."
+            )
+        return pool
+
+    async def create_version(
+        self,
+        content_id: str,
+        content: str,
+        change_type: ChangeType = ChangeType.MANUAL,
+        change_summary: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> Tuple[str, int, str, bool]:
+        """Create a new version (idempotent on an unchanged latest hash)."""
+        content_hash = calculate_content_hash(content)
+        pool = await self._pool()
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                latest = await conn.fetchrow(
+                    """
+                    SELECT id, version_number, content, content_hash
+                    FROM content_versions
+                    WHERE content_id = $1
+                    ORDER BY version_number DESC
+                    LIMIT 1
+                    """,
+                    content_id,
+                )
+
+                # De-dupe: re-saving identical content is a no-op.
+                if latest is not None and latest["content_hash"] == content_hash:
+                    return (
+                        str(latest["id"]),
+                        latest["version_number"],
+                        content_hash,
+                        True,
+                    )
+
+                version_number = (latest["version_number"] + 1) if latest else 1
+
+                diff_from_previous = None
+                if latest is not None:
+                    diff_from_previous, _, _ = generate_unified_diff(
+                        latest["content"],
+                        content,
+                        latest["version_number"],
+                        version_number,
+                    )
+
+                await conn.execute(
+                    "UPDATE content_versions SET is_current = false WHERE content_id = $1",
+                    content_id,
+                )
+
+                new_id = await conn.fetchval(
+                    """
+                    INSERT INTO content_versions (
+                        content_id, version_number, content, content_hash,
+                        diff_from_previous, change_type, change_summary,
+                        word_count, character_count, created_by, is_current
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true)
+                    RETURNING id
+                    """,
+                    content_id,
+                    version_number,
+                    content,
+                    content_hash,
+                    diff_from_previous,
+                    change_type.value,
+                    change_summary,
+                    calculate_word_count(content),
+                    len(content),
+                    created_by,
+                )
+
+        logger.info(
+            f"Created version {version_number} for content {content_id} "
+            f"(type: {change_type.value})"
+        )
+        return str(new_id), version_number, content_hash, False
+
+    async def get_versions(
+        self,
+        content_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Tuple[List[ContentVersionSummary], int]:
+        """Get paginated version history (newest first) plus total count."""
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            total = await conn.fetchval(
+                "SELECT COUNT(*) FROM content_versions WHERE content_id = $1",
+                content_id,
+            )
+            rows = await conn.fetch(
+                """
+                SELECT id, version_number, content, content_hash, change_type,
+                       change_summary, word_count, character_count, created_by,
+                       created_at, is_current
+                FROM content_versions
+                WHERE content_id = $1
+                ORDER BY version_number DESC
+                LIMIT $2 OFFSET $3
+                """,
+                content_id,
+                limit,
+                offset,
+            )
+
+        summaries = [
+            ContentVersionSummary(
+                id=str(row["id"]),
+                version_number=row["version_number"],
+                content_preview=row["content"][:200],
+                content_hash=row["content_hash"],
+                change_type=ChangeType(row["change_type"]),
+                change_summary=row["change_summary"],
+                word_count=row["word_count"],
+                character_count=row["character_count"],
+                created_by=row["created_by"],
+                created_at=row["created_at"],
+                is_current=row["is_current"],
+            )
+            for row in rows
+        ]
+        return summaries, int(total or 0)
+
+    async def get_version(
+        self,
+        content_id: str,
+        version_number: int,
+    ) -> Optional[ContentVersion]:
+        """Get a specific version."""
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT id, content_id, version_number, content, content_hash,
+                       diff_from_previous, change_type, change_summary,
+                       word_count, character_count, created_by, created_at,
+                       is_current
+                FROM content_versions
+                WHERE content_id = $1 AND version_number = $2
+                """,
+                content_id,
+                version_number,
+            )
+        return self._row_to_version(row) if row else None
+
+    async def restore_version(
+        self,
+        content_id: str,
+        version_number: int,
+        restored_by: Optional[str] = None,
+    ) -> Tuple[bool, str, int, int, str]:
+        """Restore a previous version by creating a new version from it."""
+        version = await self.get_version(content_id, version_number)
+        if not version:
+            return (False, "", 0, version_number, f"Version {version_number} not found")
+
+        version_id, new_version_number, _, _ = await self.create_version(
+            content_id=content_id,
+            content=version.content,
+            change_type=ChangeType.RESTORE,
+            change_summary=f"Restored from version {version_number}",
+            created_by=restored_by,
+        )
+        return (
+            True,
+            version_id,
+            new_version_number,
+            version_number,
+            f"Successfully restored to version {version_number} (new version: {new_version_number})",
+        )
+
+    async def compare_versions(
+        self,
+        content_id: str,
+        version_1: int,
+        version_2: int,
+    ) -> Optional[VersionComparison]:
+        """Compare two versions."""
+        v1 = await self.get_version(content_id, version_1)
+        v2 = await self.get_version(content_id, version_2)
+        if not v1 or not v2:
+            return None
+
+        unified_diff, additions, deletions = generate_unified_diff(
+            v1.content, v2.content, v1.version_number, v2.version_number
+        )
+        return VersionComparison(
+            version_1=v1,
+            version_2=v2,
+            word_count_diff=v2.word_count - v1.word_count,
+            character_count_diff=v2.character_count - v1.character_count,
+            unified_diff=unified_diff,
+            additions=additions,
+            deletions=deletions,
+        )
+
+    async def get_statistics(
+        self,
+        content_id: str,
+    ) -> Optional[VersionStatistics]:
+        """Aggregate version statistics for content."""
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT version_number, word_count, change_type, created_at
+                FROM content_versions
+                WHERE content_id = $1
+                ORDER BY version_number ASC
+                """,
+                content_id,
+            )
+        if not rows:
+            return None
+
+        total_word_change = 0
+        prev_word_count = 0
+        for row in rows:
+            total_word_change += abs(row["word_count"] - prev_word_count)
+            prev_word_count = row["word_count"]
+
+        return VersionStatistics(
+            content_id=content_id,
+            total_versions=len(rows),
+            current_version=rows[-1]["version_number"],
+            first_created_at=rows[0]["created_at"],
+            last_updated_at=rows[-1]["created_at"],
+            total_word_change=total_word_change,
+            avg_word_count=sum(r["word_count"] for r in rows) / len(rows),
+            manual_saves=sum(
+                1 for r in rows if r["change_type"] == ChangeType.MANUAL.value
+            ),
+            auto_saves=sum(
+                1 for r in rows if r["change_type"] == ChangeType.AUTO.value
+            ),
+            restores=sum(
+                1 for r in rows if r["change_type"] == ChangeType.RESTORE.value
+            ),
+        )
+
+    async def should_auto_version(
+        self,
+        content_id: str,
+        new_content: str,
+        config: Optional[AutoVersionConfig] = None,
+    ) -> bool:
+        """Check whether an automatic version should be created."""
+        if config is None:
+            config = DEFAULT_AUTO_VERSION_CONFIG
+        if not config.enabled:
+            return False
+
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            last_auto = await conn.fetchval(
+                """
+                SELECT MAX(created_at) FROM content_versions
+                WHERE content_id = $1 AND change_type = 'auto'
+                """,
+                content_id,
+            )
+            if last_auto is not None:
+                time_since = datetime.now(last_auto.tzinfo) - last_auto
+                if time_since.total_seconds() < config.min_time_between_versions:
+                    return False
+
+            recent_auto = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM content_versions
+                WHERE content_id = $1 AND change_type = 'auto'
+                  AND created_at > NOW() - INTERVAL '1 hour'
+                """,
+                content_id,
+            )
+            if int(recent_auto or 0) >= config.max_versions_per_hour:
+                return False
+
+            latest = await conn.fetchrow(
+                """
+                SELECT word_count, character_count FROM content_versions
+                WHERE content_id = $1
+                ORDER BY version_number DESC LIMIT 1
+                """,
+                content_id,
+            )
+
+        if latest is None:
+            return True
+
+        word_diff = abs(calculate_word_count(new_content) - latest["word_count"])
+        char_diff = abs(len(new_content) - latest["character_count"])
+        return (
+            word_diff >= config.min_word_change or char_diff >= config.min_char_change
+        )
+
+    async def is_content_in_organization(
+        self,
+        content_id: str,
+        organization_id: Optional[str],
+    ) -> bool:
+        """Check the registered organization for this content."""
+        if not organization_id:
+            return False
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            mapped = await conn.fetchval(
+                "SELECT organization_id FROM content_version_organizations WHERE content_id = $1",
+                content_id,
+            )
+        return mapped is not None and mapped == organization_id
+
+    async def register_content_organization(
+        self,
+        content_id: str,
+        organization_id: Optional[str],
+    ) -> bool:
+        """Register ownership on first use; reject a conflicting re-registration."""
+        if not organization_id:
+            return False
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            existing = await conn.fetchval(
+                """
+                INSERT INTO content_version_organizations (content_id, organization_id)
+                VALUES ($1, $2)
+                ON CONFLICT (content_id) DO NOTHING
+                RETURNING organization_id
+                """,
+                content_id,
+                organization_id,
+            )
+            if existing is not None:
+                return True  # freshly inserted
+            current = await conn.fetchval(
+                "SELECT organization_id FROM content_version_organizations WHERE content_id = $1",
+                content_id,
+            )
+        if current == organization_id:
+            return True
+        logger.warning(
+            "Content ownership conflict (content_id=%s, existing_org=%s, requested_org=%s).",
+            content_id,
+            current,
+            organization_id,
+        )
+        return False
+
+
 class SupabaseVersionService(BaseVersionService):
     """Supabase-backed version service for production."""
 
@@ -588,7 +982,9 @@ class SupabaseVersionService(BaseVersionService):
             self._client = create_client(self._supabase_url, self._supabase_key)
             return self._client
         except ImportError:
-            logger.error("Supabase Python client not installed. Run: pip install supabase")
+            logger.error(
+                "Supabase Python client not installed. Run: pip install supabase"
+            )
             raise RuntimeError("Supabase client not available")
         except Exception as e:
             logger.error(f"Failed to create Supabase client: {e}")
@@ -697,7 +1093,9 @@ class SupabaseVersionService(BaseVersionService):
                     word_count=row["word_count"],
                     character_count=row["character_count"],
                     created_by=row["created_by"],
-                    created_at=datetime.fromisoformat(row["created_at"].replace("Z", "+00:00")),
+                    created_at=datetime.fromisoformat(
+                        row["created_at"].replace("Z", "+00:00")
+                    ),
                     is_current=row["is_current"],
                 )
                 for row in result.data
@@ -742,7 +1140,9 @@ class SupabaseVersionService(BaseVersionService):
                 word_count=row["word_count"],
                 character_count=row["character_count"],
                 created_by=row["created_by"],
-                created_at=datetime.fromisoformat(row["created_at"].replace("Z", "+00:00")),
+                created_at=datetime.fromisoformat(
+                    row["created_at"].replace("Z", "+00:00")
+                ),
                 is_current=row["is_current"],
             )
 
@@ -865,12 +1265,20 @@ class SupabaseVersionService(BaseVersionService):
                 content_id=content_id,
                 total_versions=row["total_versions"],
                 current_version=row["current_version"],
-                first_created_at=datetime.fromisoformat(
-                    row["first_created_at"].replace("Z", "+00:00")
-                ) if row["first_created_at"] else None,
-                last_updated_at=datetime.fromisoformat(
-                    row["last_updated_at"].replace("Z", "+00:00")
-                ) if row["last_updated_at"] else None,
+                first_created_at=(
+                    datetime.fromisoformat(
+                        row["first_created_at"].replace("Z", "+00:00")
+                    )
+                    if row["first_created_at"]
+                    else None
+                ),
+                last_updated_at=(
+                    datetime.fromisoformat(
+                        row["last_updated_at"].replace("Z", "+00:00")
+                    )
+                    if row["last_updated_at"]
+                    else None
+                ),
                 total_word_change=row["total_word_change"],
                 avg_word_count=float(row["avg_word_count"] or 0),
                 manual_saves=row["manual_saves"],
@@ -971,10 +1379,20 @@ class ContentVersionService:
         if cls._instance is not None:
             return cls._instance
 
+        # Prefer the Neon/asyncpg store (the app's primary datastore). Fall back
+        # to Supabase only if explicitly configured, then to in-memory.
+        database_url = os.environ.get("DATABASE_URL_DIRECT") or os.environ.get(
+            "DATABASE_URL"
+        )
         supabase_url = os.environ.get("SUPABASE_URL")
-        supabase_key = os.environ.get("SUPABASE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY")
+        supabase_key = os.environ.get("SUPABASE_KEY") or os.environ.get(
+            "SUPABASE_SERVICE_KEY"
+        )
 
-        if supabase_url and supabase_key:
+        if database_url:
+            cls._instance = NeonVersionService()
+            logger.info("Using Neon (asyncpg) storage for content versions")
+        elif supabase_url and supabase_key:
             try:
                 cls._instance = SupabaseVersionService(supabase_url, supabase_key)
                 logger.info("Using Supabase storage for content versions")
@@ -986,7 +1404,7 @@ class ContentVersionService:
                 cls._instance = InMemoryVersionService()
         else:
             logger.info(
-                "Supabase not configured. Using in-memory storage for content versions."
+                "No database configured. Using in-memory storage for content versions."
             )
             cls._instance = InMemoryVersionService()
 

--- a/apps/api/tests/test_version_service.py
+++ b/apps/api/tests/test_version_service.py
@@ -1,0 +1,180 @@
+"""Tests for the content version service: factory selection + the Neon/asyncpg
+backend.
+
+The integration tests exercise NeonVersionService against a real Postgres and are
+skipped unless a reachable database is configured (TEST_DATABASE_URL or
+DATABASE_URL) with db/migrations applied. The factory-selection tests run
+everywhere (construction does not open a connection).
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.content.version_service import (  # noqa: E402
+    ContentVersionService,
+    InMemoryVersionService,
+    NeonVersionService,
+    SupabaseVersionService,
+)
+from src.types.version import ChangeType  # noqa: E402
+
+
+class _EnvGuard:
+    """Temporarily set/unset env vars and reset the service singleton."""
+
+    KEYS = (
+        "DATABASE_URL",
+        "DATABASE_URL_DIRECT",
+        "SUPABASE_URL",
+        "SUPABASE_KEY",
+        "SUPABASE_SERVICE_KEY",
+    )
+
+    def __init__(self, **overrides):
+        self.overrides = overrides
+
+    def __enter__(self):
+        self._saved = {k: os.environ.get(k) for k in self.KEYS}
+        for k in self.KEYS:
+            os.environ.pop(k, None)
+        for k, v in self.overrides.items():
+            os.environ[k] = v
+        ContentVersionService.reset()
+        return self
+
+    def __exit__(self, *exc):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        ContentVersionService.reset()
+
+
+class TestFactorySelection(unittest.TestCase):
+    def test_prefers_neon_when_database_url_set(self):
+        with _EnvGuard(DATABASE_URL="postgresql://x@/db"):
+            self.assertIsInstance(
+                ContentVersionService.get_service(), NeonVersionService
+            )
+
+    def test_uses_supabase_when_only_supabase_configured(self):
+        with _EnvGuard(SUPABASE_URL="https://x.supabase.co", SUPABASE_KEY="k"):
+            self.assertIsInstance(
+                ContentVersionService.get_service(), SupabaseVersionService
+            )
+
+    def test_falls_back_to_in_memory_when_nothing_configured(self):
+        with _EnvGuard():
+            self.assertIsInstance(
+                ContentVersionService.get_service(), InMemoryVersionService
+            )
+
+
+def _reachable_db_url():
+    """Return a DB URL with content_versions present, or None to skip.
+
+    Evaluated once at import time (no running event loop), so it can safely spin
+    up its own loop via asyncio.run.
+    """
+    url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not url:
+        return None
+    try:
+        import asyncpg
+
+        async def _check():
+            conn = await asyncpg.connect(dsn=url, statement_cache_size=0)
+            try:
+                return await conn.fetchval(
+                    "SELECT to_regclass('public.content_versions')"
+                )
+            finally:
+                await conn.close()
+
+        return url if asyncio.run(_check()) else None
+    except Exception:
+        return None
+
+
+_DB_URL = _reachable_db_url()
+
+
+@unittest.skipUnless(_DB_URL, "no reachable Postgres with content_versions")
+class TestNeonVersionServiceIntegration(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self._saved_db_url = os.environ.get("DATABASE_URL")
+        os.environ["DATABASE_URL"] = _DB_URL
+        ContentVersionService.reset()
+        from src.db import get_pool
+
+        self.pool = await get_pool()
+        self.cid = f"itest-{os.getpid()}-{id(self)}"
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM content_versions WHERE content_id = $1", self.cid
+            )
+            await conn.execute(
+                "DELETE FROM content_version_organizations WHERE content_id = $1",
+                self.cid,
+            )
+        self.svc = ContentVersionService.get_service()
+
+    async def asyncTearDown(self):
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM content_versions WHERE content_id = $1", self.cid
+            )
+            await conn.execute(
+                "DELETE FROM content_version_organizations WHERE content_id = $1",
+                self.cid,
+            )
+        # Each IsolatedAsyncioTestCase runs on its own event loop; close the
+        # cached pool so the next test rebuilds one bound to its loop.
+        from src.db import close_pool
+
+        await close_pool()
+        ContentVersionService.reset()
+        if self._saved_db_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = self._saved_db_url
+
+    async def test_create_dedup_list_and_current_flag(self):
+        _, n1, _, dup1 = await self.svc.create_version(
+            self.cid, "alpha", ChangeType.INITIAL
+        )
+        self.assertEqual((n1, dup1), (1, False))
+        _, n2, _, dup2 = await self.svc.create_version(self.cid, "alpha")
+        self.assertEqual((n2, dup2), (1, True))  # identical -> no new version
+        await self.svc.create_version(self.cid, "alpha beta gamma")
+        versions, total = await self.svc.get_versions(self.cid)
+        self.assertEqual(total, 2)
+        self.assertEqual([v.version_number for v in versions], [2, 1])  # newest first
+        self.assertEqual([v.version_number for v in versions if v.is_current], [2])
+
+    async def test_restore_and_statistics(self):
+        await self.svc.create_version(self.cid, "one", ChangeType.INITIAL)
+        await self.svc.create_version(self.cid, "one two three")
+        ok, _, new_no, frm, _ = await self.svc.restore_version(self.cid, 1)
+        self.assertTrue(ok)
+        self.assertEqual((new_no, frm), (3, 1))
+        stats = await self.svc.get_statistics(self.cid)
+        self.assertEqual(stats.total_versions, 3)
+        self.assertEqual(stats.current_version, 3)
+        self.assertEqual(stats.restores, 1)
+
+    async def test_ownership_register_and_conflict(self):
+        await self.svc.create_version(self.cid, "x", ChangeType.INITIAL)
+        self.assertFalse(await self.svc.is_content_in_organization(self.cid, "org1"))
+        self.assertTrue(await self.svc.register_content_organization(self.cid, "org1"))
+        self.assertTrue(await self.svc.is_content_in_organization(self.cid, "org1"))
+        self.assertFalse(await self.svc.register_content_organization(self.cid, "org2"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/db/migrations/007_content_versions.sql
+++ b/db/migrations/007_content_versions.sql
@@ -1,0 +1,46 @@
+-- Migration 007: Content versioning (Neon/asyncpg port of the Supabase module)
+--
+-- Backs NeonVersionService (src/content/version_service.py), the asyncpg
+-- implementation of content versioning. Previously this feature only worked
+-- against a separate Supabase project (supabase/migrations/009) via supabase-py;
+-- this brings it onto the Neon datastore the rest of the app uses.
+--
+-- Feature stays gated behind ENABLE_CONTENT_VERSIONING (default off); these
+-- tables are inert until it's enabled. Portable/idempotent: no RLS, no Supabase
+-- role grants. content_id is an opaque TEXT key (not FK'd to generated_content,
+-- whose id is UUID) so any content identifier can be versioned, matching the
+-- in-memory implementation's contract.
+
+CREATE TABLE IF NOT EXISTS content_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  content_id text NOT NULL,
+  version_number integer NOT NULL,
+  content text NOT NULL,
+  content_hash text NOT NULL,
+  diff_from_previous text,
+  change_type text NOT NULL DEFAULT 'manual'
+    CHECK (change_type IN ('manual', 'auto', 'restore', 'initial')),
+  change_summary text,
+  word_count integer NOT NULL DEFAULT 0,
+  character_count integer NOT NULL DEFAULT 0,
+  created_by text,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  is_current boolean NOT NULL DEFAULT true,
+  UNIQUE (content_id, version_number)
+);
+
+-- History lookups (newest first) and duplicate detection by hash.
+CREATE INDEX IF NOT EXISTS idx_content_versions_content_id
+  ON content_versions(content_id, version_number DESC);
+CREATE INDEX IF NOT EXISTS idx_content_versions_hash
+  ON content_versions(content_id, content_hash);
+
+-- Per-content organization ownership, registered on first version create and
+-- checked on every subsequent operation (the Neon equivalent of the in-memory
+-- ownership map; the Supabase path read generated_content.organization_id, a
+-- column the Neon generated_content table does not have).
+CREATE TABLE IF NOT EXISTS content_version_organizations (
+  content_id text PRIMARY KEY,
+  organization_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);

--- a/scripts/schema_smoke.sql
+++ b/scripts/schema_smoke.sql
@@ -25,6 +25,8 @@ DECLARE
     'app_workflows',
     'audit_logs',
     'blog_posts',
+    'content_versions',
+    'content_version_organizations',
     'brand_profiles',
     'generated_content',
     'organization_invites',


### PR DESCRIPTION
## What & why

First module in the **Supabase → Neon migration** the corrected audit (#125) calls for. Content versioning previously worked only against a separate Supabase project via `supabase-py` (with an in-memory fallback), so on the Neon-only deployment it never persisted. This brings it onto the Neon datastore the rest of the app uses.

## Changes

- **`db/migrations/007_content_versions.sql`** — `content_versions` (+ a `content_version_organizations` ownership map). Portable/idempotent, no RLS; `content_id` is an opaque `TEXT` key (the Neon `generated_content.id` is UUID and has no `organization_id` column, so the Supabase ownership-via-`generated_content` path doesn't apply — ownership is registered on first version, like the in-memory impl).
- **`NeonVersionService`** — asyncpg implementation of all 9 `BaseVersionService` methods (create + dedup, list/paginate + `is_current`, get, restore, compare, statistics, auto-version policy, org ownership/conflict), mirroring `InMemoryVersionService` semantics but durably.
- **Factory** now prefers Neon when `DATABASE_URL` is set, then Supabase, then in-memory. Feature stays gated behind `ENABLE_CONTENT_VERSIONING` (default off) — this makes it *work* when enabled, it doesn't enable it.
- **`scripts/schema_smoke.sql`** asserts the new tables.
- **New `backend-db-tests` CI job** boots Postgres, applies `db/migrations`, and runs the asyncpg integration tests (they skip in the no-DB `backend-tests` job). Gives the ported code real CI coverage and sets up infra for the analytics/KB ports next.

## Verification
- Validated `NeonVersionService` end-to-end against a real Postgres 16 (socket + TCP): dedup, newest-first pagination + current-flag, compare, restore, statistics, and ownership-conflict all behave identically to the in-memory reference.
- Full backend suite green (`pytest -q`); migration applies cleanly + idempotently; `schema_smoke.sql` passes (26 tables); `black`/`isort`/`ruff` clean.

## Follow-ups (same migration effort)
Analytics/SEO (`supabase/015`, 5 tables) and knowledge base (`supabase/010`, `kb_documents`) are the remaining live Supabase-dependent modules to port the same way.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_