### PR TITLE
feat(kb): port knowledge-base document metadata from Supabase to Neon/asyncpg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
           DEV_MODE: "true"
           OPENAI_API_KEY: "test"
         run: |
-          pytest tests/test_version_service.py -q
+          pytest tests/test_version_service.py tests/test_knowledge_metadata.py -q
 
   security-scan:
     name: Security Scan

--- a/apps/api/src/knowledge/knowledge_service.py
+++ b/apps/api/src/knowledge/knowledge_service.py
@@ -13,35 +13,33 @@ Features:
 - Multi-tenant support with user isolation
 """
 
-import asyncio
+import json
 import logging
 import os
 import time
-import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from ..types.knowledge import (
     ChunkingConfig,
     Citation,
     Document,
     DocumentChunk,
+    DocumentMetadata,
     DocumentType,
-    DocumentUploadRequest,
     DocumentUploadResponse,
     EmbeddingConfig,
     EmbeddingProvider,
     KnowledgeBaseStats,
     KnowledgeContext,
-    KnowledgeSearchRequest,
     SearchFilter,
     SearchResponse,
     SearchResult,
     VectorStoreConfig,
     VectorStoreProvider,
 )
-from .document_processor import DocumentProcessor, DocumentProcessingError
-from .embeddings import EmbeddingGenerator, EmbeddingError
+from .document_processor import DocumentProcessingError, DocumentProcessor
+from .embeddings import EmbeddingError, EmbeddingGenerator
 from .vector_store import VectorStore, VectorStoreError, create_vector_store
 
 logger = logging.getLogger(__name__)
@@ -97,8 +95,22 @@ class KnowledgeService:
         self.supabase = supabase_client
         self._initialized = False
 
-        # In-memory document metadata cache (for when Supabase is not available)
+        # In-memory document metadata cache (used only when neither the Neon
+        # pool nor Supabase is available).
         self._document_cache: Dict[str, Document] = {}
+
+    async def _metadata_pool(self):
+        """Return the Neon asyncpg pool for kb_documents metadata, or None.
+
+        Neon is the primary metadata store (DATABASE_URL); Supabase and the
+        in-memory cache remain fallbacks for environments without it.
+        """
+        try:
+            from ..db import get_pool
+
+            return await get_pool()
+        except Exception:  # pragma: no cover - defensive
+            return None
 
     @classmethod
     def from_env(cls) -> "KnowledgeService":
@@ -401,9 +413,11 @@ class KnowledgeService:
                 page_number=result.page_number,
                 section_title=result.section_title,
                 relevance_score=result.score,
-                excerpt=result.content[:200] + "..."
-                if len(result.content) > 200
-                else result.content,
+                excerpt=(
+                    result.content[:200] + "..."
+                    if len(result.content) > 200
+                    else result.content
+                ),
             )
             citations.append(citation)
 
@@ -453,7 +467,7 @@ class KnowledgeService:
         # Add citation reference
         citation_refs = "\n\nSource References:\n"
         for citation in citations:
-            ref = f"- {citation.id}: \"{citation.document_title}\""
+            ref = f'- {citation.id}: "{citation.document_title}"'
             if citation.page_number:
                 ref += f" (p. {citation.page_number})"
             if citation.section_title:
@@ -515,6 +529,25 @@ class KnowledgeService:
         Returns:
             List of Document objects
         """
+        pool = await self._metadata_pool()
+        if pool:
+            try:
+                async with pool.acquire() as conn:
+                    rows = await conn.fetch(
+                        """
+                        SELECT * FROM kb_documents
+                        WHERE user_id = $1
+                        ORDER BY created_at DESC
+                        LIMIT $2 OFFSET $3
+                        """,
+                        user_id,
+                        limit,
+                        offset,
+                    )
+                return [self._row_to_document(dict(row)) for row in rows]
+            except Exception as e:
+                logger.error(f"Failed to list documents from Neon: {e}")
+
         if self.supabase:
             try:
                 response = (
@@ -538,16 +571,12 @@ class KnowledgeService:
 
         # Fallback to in-memory cache
         user_docs = [
-            doc
-            for doc in self._document_cache.values()
-            if doc.user_id == user_id
+            doc for doc in self._document_cache.values() if doc.user_id == user_id
         ]
         user_docs.sort(key=lambda d: d.created_at, reverse=True)
         return user_docs[offset : offset + limit]
 
-    async def get_document(
-        self, document_id: str, user_id: str
-    ) -> Optional[Document]:
+    async def get_document(self, document_id: str, user_id: str) -> Optional[Document]:
         """
         Get a specific document by ID.
 
@@ -558,6 +587,19 @@ class KnowledgeService:
         Returns:
             Document if found and owned by user, None otherwise
         """
+        pool = await self._metadata_pool()
+        if pool:
+            try:
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow(
+                        "SELECT * FROM kb_documents WHERE id = $1 AND user_id = $2",
+                        document_id,
+                        user_id,
+                    )
+                return self._row_to_document(dict(row)) if row else None
+            except Exception as e:
+                logger.error(f"Failed to get document from Neon: {e}")
+
         if self.supabase:
             try:
                 response = (
@@ -635,7 +677,48 @@ class KnowledgeService:
             )
 
     async def _store_document_metadata(self, document: Document) -> None:
-        """Store document metadata in Supabase or cache."""
+        """Store document metadata in Neon, Supabase, or the in-memory cache."""
+        pool = await self._metadata_pool()
+        if pool:
+            try:
+                async with pool.acquire() as conn:
+                    await conn.execute(
+                        """
+                        INSERT INTO kb_documents (
+                            id, user_id, filename, title, file_type,
+                            file_size_bytes, page_count, chunk_count, status,
+                            metadata, created_at, updated_at
+                        ) VALUES (
+                            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12
+                        )
+                        ON CONFLICT (id) DO UPDATE SET
+                            filename = EXCLUDED.filename,
+                            title = EXCLUDED.title,
+                            file_type = EXCLUDED.file_type,
+                            file_size_bytes = EXCLUDED.file_size_bytes,
+                            page_count = EXCLUDED.page_count,
+                            chunk_count = EXCLUDED.chunk_count,
+                            status = EXCLUDED.status,
+                            metadata = EXCLUDED.metadata,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        document.id,
+                        document.user_id,
+                        document.filename,
+                        document.metadata.title,
+                        document.metadata.file_type.value,
+                        document.metadata.file_size_bytes,
+                        document.metadata.page_count,
+                        document.chunk_count,
+                        document.status,
+                        json.dumps(document.metadata.custom_metadata or {}),
+                        document.created_at,
+                        document.updated_at,
+                    )
+                return
+            except Exception as e:
+                logger.warning(f"Failed to store document in Neon: {e}")
+
         if self.supabase:
             try:
                 self.supabase.table("kb_documents").upsert(
@@ -661,15 +744,26 @@ class KnowledgeService:
         # Fallback to in-memory cache
         self._document_cache[document.id] = document
 
-    async def _delete_document_metadata(
-        self, document_id: str, user_id: str
-    ) -> None:
-        """Delete document metadata from Supabase or cache."""
+    async def _delete_document_metadata(self, document_id: str, user_id: str) -> None:
+        """Delete document metadata from Neon, Supabase, or the cache."""
+        pool = await self._metadata_pool()
+        if pool:
+            try:
+                async with pool.acquire() as conn:
+                    await conn.execute(
+                        "DELETE FROM kb_documents WHERE id = $1 AND user_id = $2",
+                        document_id,
+                        user_id,
+                    )
+                return
+            except Exception as e:
+                logger.warning(f"Failed to delete document from Neon: {e}")
+
         if self.supabase:
             try:
-                self.supabase.table("kb_documents").delete().eq(
-                    "id", document_id
-                ).eq("user_id", user_id).execute()
+                self.supabase.table("kb_documents").delete().eq("id", document_id).eq(
+                    "user_id", user_id
+                ).execute()
                 return
             except Exception as e:
                 logger.warning(f"Failed to delete document from Supabase: {e}")
@@ -705,15 +799,35 @@ class KnowledgeService:
 
         return results
 
+    @staticmethod
+    def _coerce_dt(value: Any) -> datetime:
+        """Accept a datetime (asyncpg timestamptz) or ISO string (Supabase)."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return datetime.now()
+        return datetime.now()
+
     def _row_to_document(self, row: Dict[str, Any]) -> Document:
         """Convert a database row to a Document object."""
+        # jsonb comes back as a str from asyncpg and as a dict from Supabase.
+        custom = row.get("metadata", {})
+        if isinstance(custom, str):
+            try:
+                custom = json.loads(custom)
+            except (ValueError, TypeError):
+                custom = {}
+
         metadata = DocumentMetadata(
             title=row.get("title", row.get("filename", "")),
             source=row.get("filename", ""),
             file_type=DocumentType(row.get("file_type", "txt")),
             file_size_bytes=row.get("file_size_bytes", 0),
             page_count=row.get("page_count"),
-            custom_metadata=row.get("metadata", {}),
+            custom_metadata=custom or {},
         )
 
         return Document(
@@ -724,12 +838,8 @@ class KnowledgeService:
             metadata=metadata,
             status=row.get("status", "ready"),
             chunk_count=row.get("chunk_count", 0),
-            created_at=datetime.fromisoformat(row["created_at"])
-            if row.get("created_at")
-            else datetime.now(),
-            updated_at=datetime.fromisoformat(row["updated_at"])
-            if row.get("updated_at")
-            else datetime.now(),
+            created_at=self._coerce_dt(row.get("created_at")),
+            updated_at=self._coerce_dt(row.get("updated_at")),
         )
 
     async def close(self) -> None:

--- a/apps/api/tests/test_knowledge_metadata.py
+++ b/apps/api/tests/test_knowledge_metadata.py
@@ -1,0 +1,131 @@
+"""Integration tests for the Neon/asyncpg knowledge-base document metadata path.
+
+Skipped unless a reachable Postgres with kb_documents is configured
+(TEST_DATABASE_URL or DATABASE_URL). Exercises KnowledgeService's metadata
+operations and the kb_usage_stats view consumed by quota.py.
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _reachable_db_url():
+    url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not url:
+        return None
+    try:
+        import asyncpg
+
+        async def _check():
+            conn = await asyncpg.connect(dsn=url, statement_cache_size=0)
+            try:
+                return await conn.fetchval("SELECT to_regclass('public.kb_documents')")
+            finally:
+                await conn.close()
+
+        return url if asyncio.run(_check()) else None
+    except Exception:
+        return None
+
+
+_DB_URL = _reachable_db_url()
+
+
+@unittest.skipUnless(_DB_URL, "no reachable Postgres with kb_documents")
+class TestKnowledgeMetadataNeon(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self._saved = os.environ.get("DATABASE_URL")
+        os.environ["DATABASE_URL"] = _DB_URL
+
+        from src.knowledge.knowledge_service import KnowledgeService
+        from src.types.knowledge import Document, DocumentMetadata, DocumentType
+
+        self._Document = Document
+        self._DocumentMetadata = DocumentMetadata
+        self._DocumentType = DocumentType
+        # Only the metadata methods are exercised; the heavy components are unused.
+        self.svc = KnowledgeService(None, None, None)
+        self.uid = f"kbuser-{os.getpid()}-{id(self)}"
+
+        from src.db import get_pool
+
+        self.pool = await get_pool()
+        async with self.pool.acquire() as conn:
+            await conn.execute("DELETE FROM kb_documents WHERE user_id = $1", self.uid)
+
+    async def asyncTearDown(self):
+        async with self.pool.acquire() as conn:
+            await conn.execute("DELETE FROM kb_documents WHERE user_id = $1", self.uid)
+        from src.db import close_pool
+
+        await close_pool()
+        if self._saved is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = self._saved
+
+    def _doc(self, doc_id, **over):
+        md = self._DocumentMetadata(
+            title=over.get("title", "Doc"),
+            source="f.txt",
+            file_type=self._DocumentType.TXT,
+            file_size_bytes=over.get("size", 100),
+            page_count=2,
+            custom_metadata=over.get("meta", {"k": "v"}),
+        )
+        return self._Document(
+            id=doc_id,
+            user_id=self.uid,
+            filename="f.txt",
+            content="",
+            metadata=md,
+            status="ready",
+            chunk_count=over.get("chunks", 1),
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+    async def test_store_get_roundtrip_with_jsonb(self):
+        await self.svc._store_document_metadata(self._doc("d1", meta={"a": 1}))
+        got = await self.svc.get_document("d1", self.uid)
+        self.assertIsNotNone(got)
+        self.assertEqual(got.metadata.custom_metadata, {"a": 1})
+        self.assertEqual(got.metadata.file_size_bytes, 100)
+
+    async def test_ownership_isolation(self):
+        await self.svc._store_document_metadata(self._doc("d1"))
+        self.assertIsNone(await self.svc.get_document("d1", "someone-else"))
+
+    async def test_upsert_updates_in_place(self):
+        await self.svc._store_document_metadata(self._doc("d1", chunks=1, title="A"))
+        await self.svc._store_document_metadata(self._doc("d1", chunks=7, title="B"))
+        got = await self.svc.get_document("d1", self.uid)
+        self.assertEqual((got.chunk_count, got.metadata.title), (7, "B"))
+        docs = await self.svc.list_documents(self.uid)
+        self.assertEqual(len(docs), 1)  # upsert, not duplicate
+
+    async def test_list_and_delete(self):
+        await self.svc._store_document_metadata(self._doc("d1"))
+        await self.svc._store_document_metadata(self._doc("d2"))
+        self.assertEqual(len(await self.svc.list_documents(self.uid)), 2)
+        await self.svc._delete_document_metadata("d1", self.uid)
+        remaining = await self.svc.list_documents(self.uid)
+        self.assertEqual([d.id for d in remaining], ["d2"])
+
+    async def test_kb_usage_stats_view(self):
+        await self.svc._store_document_metadata(self._doc("d1", size=400))
+        await self.svc._store_document_metadata(self._doc("d2", size=600))
+        from src.knowledge.quota import _get_kb_usage
+
+        usage = await _get_kb_usage(self.uid)
+        self.assertEqual(usage["document_count"], 2)
+        self.assertEqual(usage["total_storage_bytes"], 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/db/migrations/008_knowledge_base.sql
+++ b/db/migrations/008_knowledge_base.sql
@@ -1,0 +1,41 @@
+-- Migration 008: Knowledge-base document metadata (Neon/asyncpg port)
+--
+-- Second module in the Supabase -> Neon migration (see docs/SCHEMA_AUDIT.md).
+-- Backs the document-metadata layer of src/knowledge/knowledge_service.py, which
+-- previously stored kb_documents in a separate Supabase project (with an
+-- in-memory cache fallback). The vector embeddings remain in the pluggable
+-- VectorStore (Chroma/Pinecone); only the relational metadata moves to Neon.
+--
+-- Columns mirror exactly what knowledge_service reads/writes (the upsert dict and
+-- _row_to_document). Plain relational types only — no pgvector — so this runs on
+-- the standard Postgres CI image. Feature stays gated behind ENABLE_KNOWLEDGE_BASE
+-- (default off). Idempotent and portable (no RLS/role grants).
+
+CREATE TABLE IF NOT EXISTS kb_documents (
+  id text PRIMARY KEY,
+  user_id text NOT NULL,
+  filename text NOT NULL DEFAULT '',
+  title text NOT NULL DEFAULT '',
+  file_type text NOT NULL DEFAULT 'txt',
+  file_size_bytes bigint NOT NULL DEFAULT 0,
+  page_count integer,
+  chunk_count integer NOT NULL DEFAULT 0,
+  status text NOT NULL DEFAULT 'ready',
+  metadata jsonb NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+-- List documents per user, newest first.
+CREATE INDEX IF NOT EXISTS idx_kb_documents_user_created
+  ON kb_documents(user_id, created_at DESC);
+
+-- Per-user usage aggregate consumed by src/knowledge/quota.py (_get_kb_usage,
+-- which already reads this view through the Neon pool).
+CREATE OR REPLACE VIEW kb_usage_stats AS
+SELECT
+  user_id,
+  COUNT(*)                                  AS document_count,
+  COALESCE(SUM(file_size_bytes), 0)::bigint AS total_storage_bytes
+FROM kb_documents
+GROUP BY user_id;

--- a/scripts/schema_smoke.sql
+++ b/scripts/schema_smoke.sql
@@ -8,10 +8,13 @@
 -- Usage (after applying db/migrations against the target database):
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/schema_smoke.sql
 --
+-- kb_documents (knowledge-base metadata) is in the runner as of migration 008
+-- and asserted above; the kb_usage_stats view is created alongside it.
+--
 -- Intentionally NOT required here:
---   * kb_documents / kb_embeddings / kb_usage_stats — gated behind
---     ENABLE_KNOWLEDGE_BASE and need the pgvector extension, so they live in
---     apps/api/migrations/002_knowledge_base.sql, outside the default runner.
+--   * Vector-embedding storage (kb_chunks/kb_embeddings) — the knowledge base
+--     stores vectors in the pluggable VectorStore (Chroma/Pinecone), not Neon;
+--     a pgvector backend would need the pgvector extension.
 --   * webhook_* (outbound webhooks) — the webhook store is Redis/memory backed;
 --     no code references those tables.
 
@@ -27,6 +30,7 @@ DECLARE
     'blog_posts',
     'content_versions',
     'content_version_organizations',
+    'kb_documents',
     'brand_profiles',
     'generated_content',
     'organization_invites',


### PR DESCRIPTION
## What & why

Second module in the **Supabase → Neon migration** (after content versioning #126). The knowledge base stored `kb_documents` metadata in a separate Supabase project (with an in-memory cache fallback), so on the Neon-only deployment document metadata never persisted. This moves the relational metadata to Neon.

**Scope:** metadata only. The vector embeddings stay in the pluggable `VectorStore` (Chroma default / Pinecone) — there is currently *no* Postgres vector-store backend (`VectorStoreProvider.PGVECTOR` is declared but unimplemented), so a true pgvector backend is a separate, larger follow-up. Because this is metadata-only it needs **no pgvector extension** and runs on the standard Postgres CI image.

## Changes

- **`db/migrations/008_knowledge_base.sql`** — `kb_documents` (columns mirror exactly what `knowledge_service` reads/writes: `file_size_bytes`, `page_count`, `chunk_count`, `metadata` jsonb, `timestamptz` timestamps) + the `kb_usage_stats` view that `quota.py` already reads through the Neon pool. Plain types, idempotent, no RLS.
- **`knowledge_service.py`** — Neon (asyncpg) metadata path for store/list/get/delete, preferred when `DATABASE_URL` is set, with Supabase → in-memory cache as fallbacks. Correct jsonb (`::jsonb` + `json.loads`) and `timestamptz` handling on both sides.
- **Latent-bug fix:** `_row_to_document` referenced `DocumentMetadata`, which was never imported — the Supabase read path would have raised `NameError` if it had ever run. Now imported, and the method tolerates `datetime`/dict (asyncpg) as well as ISO-string/dict (Supabase). Also removed pre-existing unused imports ruff flagged in the touched file.
- **`scripts/schema_smoke.sql`** asserts `kb_documents`; the `backend-db-tests` CI job now also runs the KB metadata integration tests.

Feature stays gated behind `ENABLE_KNOWLEDGE_BASE` (default off).

## Verification
- End-to-end on local Postgres 16: store/get/list/delete, jsonb round-trip, ownership isolation, in-place upsert, and the `kb_usage_stats` aggregate via `quota.py`.
- Full backend suite green; migration applies cleanly + idempotently; `schema_smoke.sql` passes (27 tables); `ruff` clean.

## Remaining
Analytics/SEO (`supabase/015`, 5 tables, 4 services, ~3,270 lines) is the last and largest Supabase-dependent module to port. A Postgres/pgvector `VectorStore` backend (to move KB embeddings into Neon too) is an optional further step.

https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHazdw51Rnqi9f5UhW9ZzD)_