### PR TITLE
content: draft blog post on brand-voice AI workflow

### DIFF
--- a/content/drafts/keep-ai-content-on-brand.md
+++ b/content/drafts/keep-ai-content-on-brand.md
@@ -1,0 +1,50 @@
+---
+title: How to Keep AI Content On-Brand Without Rewriting Every Draft
+date: 2026-07-13
+excerpt: A practical workflow for training an AI writing tool on your brand voice so drafts ship with less rewriting, not more.
+slug: keep-ai-content-on-brand
+tags: [brand-voice, seo, ai-writing, content-ops]
+draft: true
+---
+
+## Why AI drafts still need a full rewrite
+
+Most teams that try AI content tools hit the same wall: the first draft is fast, but it reads like nobody in particular wrote it. Generic transitions, generic hooks, adjectives that could belong to any company in the category. So an editor spends as long fixing the voice as they would have spent writing the thing from scratch, and the "speed" promise quietly disappears.
+
+The fix isn't a better one-off prompt. It's giving the tool a standing reference for how your brand actually talks, so that reference gets applied automatically on every generation instead of re-explained every time.
+
+## Train the voice once, not per-prompt
+
+A brand voice profile is a small, reusable asset: tone, vocabulary, audience, and a few paragraphs of your own best writing as examples. Set it up once in /brand, and every draft generated afterward — blog posts, landing pages, campaign copy — starts from that positioning instead of a blank prompt.
+
+The difference shows up immediately in editing time. A prompt-only workflow needs a voice pass on every single draft. A trained profile needs spot checks, because the baseline is already close.
+
+### Tone and vocabulary
+
+Be specific rather than adjective-heavy. "Confident but not salesy" is harder for a model to apply consistently than a short list of words you use and words you avoid, plus two or three sentences pulled straight from your existing site copy.
+
+### Audience and positioning
+
+Name who the content is for and what they already believe. A profile written for "marketing teams" behaves differently than one written for "solo operators publishing on a tight schedule" — the second produces shorter sentences and fewer caveats, because that's what the audience actually wants.
+
+### Sample copy, not just adjectives
+
+The single highest-leverage input is real copy you've already published. A model matching against three paragraphs of your actual writing will get closer to your voice than a model matching against a paragraph describing your voice.
+
+## Building a repeatable SEO workflow around it
+
+Once the voice profile exists, the second piece is a workflow you don't have to reinvent per topic: outline structure, keyword targeting, and formatting that's already publish-ready. That's what turns "generate a blog post" into a repeatable production line instead of a one-off request. For teams publishing on a calendar, /generate supports queuing multiple topics at once — with cost estimated before you run the batch — so a week's worth of drafts can come out of one session instead of one prompt at a time.
+
+## Where fact-checking fits in
+
+Voice consistency solves how something sounds. It doesn't solve whether a claim in the draft is true. Content workflows that pull from live web sources (SerpAPI, Tavily, Metaphor) and cross-reference extracted claims against those sources catch the kind of confident-but-wrong statement that's the fastest way to lose reader trust — and the fastest way to need a full rewrite anyway, voice notwithstanding.
+
+## A five-minute setup checklist
+
+- Pull three paragraphs of your best existing copy — not a summary of your voice, the actual copy.
+- Write down five words you use and three you'd never use.
+- Name the specific audience segment, not just "our customers."
+- Save it as a profile once, in /brand, instead of pasting it into every prompt.
+- Run one real topic through the workflow and compare editing time against your last AI draft.
+
+The goal isn't zero editing. It's making the first draft close enough that editing is a pass, not a rewrite. Check /pricing for which plan includes brand voice training, and /tools for the full list of workflows it applies to.


### PR DESCRIPTION
Consolidates the stranded `content/20260713` branch into the PR queue.

Adds one draft post, `content/drafts/keep-ai-content-on-brand.md` (50 lines). Draft-only: it lands in `content/drafts/`, not `content/blog/`, so the blog index/sitemap loader does not pick it up until a human moves it over. Targets search intent around keeping AI content on-brand, mapping to the Brand Voice Training / SEO workflow features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)