### PR TITLE
fix(security): raise python-multipart and black floors past all 9 open alerts

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,7 +18,7 @@ python-dotenv = "^1.0.0"
 fastapi = ">=0.115.0,<1.0.0"
 uvicorn = "^0.27.0"
 websockets = "^12.0"
-python-multipart = "^0.0.9"
+python-multipart = ">=0.0.31,<0.1.0"
 uvloop = { version = "^0.19.0", markers = "platform_system != 'Windows'" }
 
 # Transitive dependency pins (security)
@@ -48,7 +48,7 @@ sentry-sdk = { version = "^1.40.0", extras = ["fastapi"] }
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.2,<10"
 pytest-asyncio = "^1.3.0"
-black = "^24.3.0"
+black = "^26.3.1"
 isort = "^7.0.0"
 mypy = "^1.5.1"
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -20,7 +20,7 @@ protobuf>=5.29.6  # CVE: JSON recursion depth bypass (transitive via google-gene
 fastapi>=0.115.0,<1.0.0
 uvicorn>=0.27.0,<1.0.0
 websockets>=12.0
-python-multipart>=0.0.9
+python-multipart>=0.0.31  # CVEs: DoS via malformed multipart boundaries/parts (8 alerts)
 uvloop>=0.19.0; platform_system != "Windows"
 
 # Postgres driver (Neon / managed Postgres)
@@ -49,6 +49,6 @@ sentry-sdk[fastapi]>=1.40.0
 # Optional development dependencies
 # pytest>=7.4.0
 # pytest-asyncio>=1.3.0
-# black>=24.3.0
+# black>=26.3.1
 # isort>=7.0.0
 # mypy>=1.5.1


### PR DESCRIPTION
## What changed
- `apps/api/requirements.txt`: `python-multipart>=0.0.31` — clears the 8-alert multipart DoS series.
- `apps/api/pyproject.toml`: `python-multipart = ">=0.0.31,<0.1.0"` (poetry's `^0.0.9` caret means `<0.0.10`, i.e. it was *holding* the vulnerable version) and `black = "^26.3.1"` (alert #80's patched floor).

Coexists with #156 (different lines in the same files; both merge orders work).

## How it was verified
`pip install --dry-run -r apps/api/requirements.txt` resolves cleanly with the new floors; `tomllib` parses the pyproject. CI on this PR is the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)